### PR TITLE
Prevent 2 cases of constantly thrown exceptions

### DIFF
--- a/src/Hud/UI/Renderers/FontRenderer.cs
+++ b/src/Hud/UI/Renderers/FontRenderer.cs
@@ -26,6 +26,9 @@ namespace PoeHUD.Hud.UI.Renderers
 
         public Size2 DrawText(string text, string fontName, int height, Vector2 position, Color color, FontDrawFlags align)
         {
+            if (text.Length == 0) {
+                return new Size2();
+            }
             try
             {
                 var font = GetFont(fontName, height);

--- a/src/Poe/Elements/ItemOnGroundTooltip.cs
+++ b/src/Poe/Elements/ItemOnGroundTooltip.cs
@@ -2,7 +2,7 @@
 {
     public class ItemOnGroundTooltip : Element
     {
-        public Element Tooltip => GetChildAtIndex(0).GetChildAtIndex(1);
-        public Element TooltipUI => GetChildAtIndex(0).GetChildAtIndex(0);
+        public Element Tooltip => GetChildAtIndex(0) == null ? null : GetChildAtIndex(0).GetChildAtIndex(1);
+        public Element TooltipUI => GetChildAtIndex(0) == null ? null : GetChildAtIndex(0).GetChildAtIndex(0);
     }
 }


### PR DESCRIPTION
Especially the NullReferenceException in ItemOnGroundTooltip was occassionally uncaught and caused crashes.