### PR TITLE
Catching initItem exceptions to prevent crashes

### DIFF
--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -181,13 +181,19 @@ namespace PoeHUD.Hud.Loot
                 }
                 else
                 {
-                    ItemUsefulProperties props = initItem(item);
-                    if (props.ShouldAlert(currencyNames, Settings))
-                    {
-                        AlertDrawStyle drawStyle = props.GetDrawStyle();
-                        PrepareForDrawingAndPlaySound(entity, drawStyle);
+                    try {
+
+                        ItemUsefulProperties props = initItem(item);
+                        if (props.ShouldAlert(currencyNames, Settings))
+                        {
+                            AlertDrawStyle drawStyle = props.GetDrawStyle();
+                            PrepareForDrawingAndPlaySound(entity, drawStyle);
+                        }
+                        Settings.Alternative.Value = false;
                     }
-                    Settings.Alternative.Value = false;
+                    catch {
+                        //initItem threw an exception because the item.Path was an empty string. This catch just prevents a crash, it doesn't fix the root of the problem.
+                    }
                 }
             }
         }


### PR DESCRIPTION
This can be used as a temporary solution to the itemInit crash. It doesn't fix the root of the problem, it just catches the exceptions so that a single item drop doesn't crash the entire program.