### PR TITLE
Fix monster_name_alerts.txt & preload_alerts.txt

### DIFF
--- a/config/monster_name_alerts.txt
+++ b/config/monster_name_alerts.txt
@@ -125,7 +125,7 @@ Metadata/Monsters/Snake/SnakeMeleeBossInvasion; Tailsinger
 Metadata/Monsters/Snake/SnakeRangedBossInvasion; Razorleaf
 Metadata/Monsters/Spawn/SpawnBossInvasion; Stranglecreep
 Metadata/Monsters/Spiders/SpiderBossInvasion; Pewterfang
-Metadata/Monsters/Spikers/SpikerBossInvasion; Bladeback Guardian
+Metadata/Monsters/Spiker/SpikerBossInvasion; Bladeback Guardian
 Metadata/Monsters/Squid/SquidBossInvasion; Strangledrift
 Metadata/Monsters/Totems/TotemBossInvasion; Jikeji
 Metadata/Monsters/Rhoas/RhoaUndeadBossInvasion; Ghostram

--- a/config/preload_alerts.txt
+++ b/config/preload_alerts.txt
@@ -3,18 +3,13 @@
 
 Metadata/QuestObjects/Labyrinth/LabyrinthTrialPortal; Labyrinth Trial; ffFF9966
 
-Metadata/Monsters/Daemon/ChestDaemonSummonRareUniqueChest2; Unique Strongbox 1; ffD2742D
-Metadata/Monsters/Daemon/ChestDaemonSummonRareUniqueChest3; Unique Strongbox 2; ffD2742D
-Metadata/Monsters/Daemon/ChestDaemonSummonRareUniqueChest4; Unique Strongbox 3; ffD2742D
-Metadata/Monsters/Daemon/BarrelOfSpidersDaemonNormal; Unique Strongbox 4; ffD2742D
-Metadata/Monsters/Daemon/BarrelOfSpidersDaemonMagic; Unique Strongbox 5; ffD2742D
-Metadata/Monsters/Daemon/BarrelOfSpidersDaemonRare; Unique Strongbox 6; ffD2742D
-Metadata/Monsters/Daemon/BarrelOfSpidersDaemonUnique; Unique Strongbox 7; ffD2742D
-Metadata/Monsters/Daemon/EternalUrnDaemonCommon; Unique Strongbox 8; ffD2742D
-Metadata/Monsters/Daemon/EternalUrnDaemonUncommon1; Unique Strongbox 9; ffD2742D
-Metadata/Monsters/Daemon/EternalUrnDaemonUncommon2; Unique Strongbox 10; ffD2742D
-Metadata/Monsters/Daemon/EternalUrnDaemonRare1; Unique Strongbox 11; ffD2742D
-Metadata/Monsters/Daemon/EternalUrnDaemonRare2; Unique Strongbox 12; ffD2742D
+Metadata/Monsters/Daemon/ChestDaemonSummonRareUniqueChest2; Kaom's Cache; ffD2742D
+Metadata/Monsters/Daemon/BarrelOfSpidersDaemonUnique; Strange Barrel; ffD2742D
+Metadata/Monsters/Daemon/EternalUrnDaemonCommon; Unique Strongbox 1; ffD2742D
+Metadata/Monsters/Daemon/EternalUrnDaemonUncommon1; Unique Strongbox 2; ffD2742D
+Metadata/Monsters/Daemon/EternalUrnDaemonUncommon2; Unique Strongbox 3; ffD2742D
+Metadata/Monsters/Daemon/EternalUrnDaemonRare1; Unique Strongbox 4; ffD2742D
+Metadata/Monsters/Daemon/EternalUrnDaemonRare2; Unique Strongbox 5; ffD2742D
 
 Metadata/Monsters/Perandus/PerandusGuardMapBoss1; Platinia, Servant of Prospero; ffFFD700
 Metadata/Monsters/Perandus/PerandusGuardMapBoss2; Auriot, Prospero's Furnace Guardian; ffFFD700


### PR DESCRIPTION
monster_name_alerts.txt:
Spikes to Spike

preload_alerts:
Combine Unique Strongbox 1, 2, 3 to Kaom's Cache.
Combine Unique Strongbox 4, 5, 6, 7 to Strange Barrel.