### PR TITLE
Require Run As admin in app manifest

### DIFF
--- a/src/app.manifest
+++ b/src/app.manifest
@@ -4,7 +4,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>


### PR DESCRIPTION
This fixes a potential issue depending on windows version and whether or not the folder is owned by the user / usergroup the program is in.