### PR TITLE
handle exception for items on the ground

### DIFF
--- a/src/Poe/Elements/InventoryItemIcon.cs
+++ b/src/Poe/Elements/InventoryItemIcon.cs
@@ -20,7 +20,16 @@ namespace PoeHUD.Poe.Elements
             itemInChatTooltip = () => ReadObject<Element>(Address + 0x7B8);
         }
 
-        public ToolTipType ToolTipType => (ToolTipType)(toolTip ?? (toolTip = GetToolTipType()));
+        public ToolTipType ToolTipType {
+            get {
+                try {
+                    return (ToolTipType)(toolTip ?? (toolTip = GetToolTipType()));
+                } catch (Exception)
+                {
+                    return ToolTipType.None;
+                }
+            }
+        }
 
         public Element Tooltip
         {


### PR DESCRIPTION
List of ground items that are in UIRoot can get In-valid (null) from valid very fast if you hover mouse on them quickly. Due to this GetToolTipType() throws an exception because it tries to read from an invalid object. This try catch will return None if there is an exception i.e. object (or object UI) doesn't exists anymore.