### PR TITLE
getting inventory item using [X,Y] format attempt 2

### DIFF
--- a/src/Poe/RemoteMemoryObjects/Inventory.cs
+++ b/src/Poe/RemoteMemoryObjects/Inventory.cs
@@ -38,5 +38,19 @@ namespace PoeHUD.Poe.RemoteMemoryObjects
                 return list;
             }
         }
+        // Will return the item based on x,y format.
+        // Give more controll to user what to do with
+        // dublicate items (items taking more than 1 slot)
+        // or slots where items doesn't exists (return null).
+        public Entity this[int x, int y, int xLength]
+        {
+            get
+            {
+                long invAddr = M.ReadLong(Address + 0x410, 0x5F0, 0x30);
+                y = y * xLength;
+                long itmAddr = M.ReadLong(invAddr + ((x + y) * 8));
+                return ReadObject<Entity>(itmAddr);
+            }
+        }
     }
 }


### PR DESCRIPTION
Now this will return item on [X,Y] format. It's generic enough to work for all inventory types.

Also, it gives user more control on what to do if that [x,y] position doesn't have an item (return with address 0). or if that [x,y] position have item which is taking more than 1 slot (return duplicate item).