### PR TITLE
Draw loot icons on map using filter border color instead of text color.

### DIFF
--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -211,7 +211,7 @@ namespace PoeHUD.Hud.Loot
         private void PrepareForDrawingAndPlaySound(EntityWrapper entity, AlertDrawStyle drawStyle)
         {
             currentAlerts.Add(entity, drawStyle);
-            CurrentIcons[entity] = new MapIcon(entity, new HudTexture("currency.png", drawStyle.TextColor), () => Settings.ShowItemOnMap, Settings.LootIcon);
+            CurrentIcons[entity] = new MapIcon(entity, new HudTexture("currency.png", drawStyle.BorderColor), () => Settings.ShowItemOnMap, Settings.LootIcon);
 
             if (Settings.PlaySound && !playedSoundsCache.Contains(entity.Id))
             {

--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -180,7 +180,7 @@ namespace PoeHUD.Hud.Loot
             if (Settings.Enable && entity != null && !GameController.Area.CurrentArea.IsTown
                 && !currentAlerts.ContainsKey(entity) && entity.HasComponent<WorldItem>())
             {
-               
+
                 IEntity item = entity.GetComponent<WorldItem>().ItemEntity;
 
                 if (Settings.Alternative && !string.IsNullOrEmpty(Settings.FilePath))
@@ -193,11 +193,11 @@ namespace PoeHUD.Hud.Loot
                     }
                 }
                 else
-                {               
+                {
                     ItemUsefulProperties props = initItem(item);
                     if (props == null)
                         return;
-                
+
                     if (props.ShouldAlert(currencyNames, Settings))
                     {
                         AlertDrawStyle drawStyle = props.GetDrawStyle();
@@ -211,7 +211,7 @@ namespace PoeHUD.Hud.Loot
         private void PrepareForDrawingAndPlaySound(EntityWrapper entity, AlertDrawStyle drawStyle)
         {
             currentAlerts.Add(entity, drawStyle);
-            CurrentIcons[entity] = new MapIcon(entity, new HudTexture("currency.png", drawStyle.BorderColor), () => Settings.ShowItemOnMap, Settings.LootIcon);
+            CurrentIcons[entity] = new MapIcon(entity, new HudTexture("currency.png", Settings.LootIconBorderColor ? drawStyle.BorderColor : drawStyle.TextColor), () => Settings.ShowItemOnMap, Settings.LootIcon);
 
             if (Settings.PlaySound && !playedSoundsCache.Contains(entity.Id))
             {

--- a/src/Hud/Loot/ItemAlertSettings.cs
+++ b/src/Hud/Loot/ItemAlertSettings.cs
@@ -26,6 +26,7 @@ namespace PoeHUD.Hud.Loot
             MinLinks = new RangeNode<int>(5, 0, 6);
             MinSockets = new RangeNode<int>(6, 0, 6);
             LootIcon = new RangeNode<int>(7, 1, 14);
+            LootIconBorderColor = false;
             QualityItems = new QualityItemsSettings();
             BorderSettings = new BorderSettings();
             WithBorder = true;
@@ -55,6 +56,7 @@ namespace PoeHUD.Hud.Loot
         public RangeNode<int> MinLinks { get; set; }
         public RangeNode<int> MinSockets { get; set; }
         public RangeNode<int> LootIcon { get; set; }
+        public ToggleNode LootIconBorderColor { get; set; }
 
         [JsonProperty("Show quality items")]
         public QualityItemsSettings QualityItems { get; set; }

--- a/src/Hud/Menu/MenuPlugin.cs
+++ b/src/Hud/Menu/MenuPlugin.cs
@@ -401,7 +401,8 @@ namespace PoeHUD.Hud.Menu
             AddChild(iconSizeMenu, "Strongboxes Icon", settingsHub.PoiTrackerSettings.StrongboxesIcon);
             AddChild(iconSizeMenu, "PerandusChest Icon", settingsHub.PoiTrackerSettings.PerandusChestIcon);
             AddChild(iconSizeMenu, "BreachChest Icon", settingsHub.PoiTrackerSettings.BreachChestIcon);
-            AddChild(iconSizeMenu, "Item loot Icon", settingsHub.ItemAlertSettings.LootIcon);
+            MenuItem itemLootIcon = AddChild(iconSizeMenu, "Item loot Icon", settingsHub.ItemAlertSettings.LootIcon);
+            AddChild(iconSizeMenu, "Use border color for loot icon", settingsHub.ItemAlertSettings.LootIconBorderColor); // Adding a ToggleNode as a RangeNode child doesn't display it
             AddChild(mapIconsMenu, "Minimap icons", settingsHub.MapIconsSettings.IconsOnMinimap);
             AddChild(mapIconsMenu, "Large map icons", settingsHub.MapIconsSettings.IconsOnLargeMap);
             AddChild(mapIconsMenu, "Drop items", settingsHub.ItemAlertSettings.ShowItemOnMap);

--- a/src/Poe/Components/Actor.cs
+++ b/src/Poe/Components/Actor.cs
@@ -13,6 +13,8 @@ namespace PoeHUD.Poe.Components
 
         public bool isMoving => (ActionId & 128) > 0;
 
+        public bool isAttacking => (ActionId & 2) > 0;
+
         public List<long> Minions
         {
             get


### PR DESCRIPTION
Much better, especially since most filters use black text color and that's barely visible on map.