### PR TITLE
Update neversink's.filter

### DIFF
--- a/config/neversink's.filter
+++ b/config/neversink's.filter
@@ -1,3795 +1,4361 @@
-#---------------------------------------------------------------------------------------------------------------
-# NeverSink's Indepth Loot Filter
-# VERSION 3.12 - Full Version
-#---------------------------------------------------------------------------------------------------------------
-#
-# You can always find the latest version here:
-#	http://pastebin.com/Af00CbhA
-# Forum discussion thread. You can post question and feedback here:
-#	http://www.pathofexile.com/forum/view-thread/1246208/page/1
-# Please use this thread for feedback, questions and suggestions
-#
-#---------------------------------------------------------------------------------------------------------------
-# INSTALLATION:
-#---------------------------------------------------------------------------------------------------------------
-#
-# 1) Select-All + Copy this script from the "RAW Paste Data" at the bottom of the page.
-# 2) Paste the contents into a notepad/txt document anywhere on your PC
-# USE ANSI ENCODING IF YOU USE NOTEPAD++ OR ANY OTHER TEXT EDITOR
-# 3) Click File/Save As and select the following settings:
-# SAVE AS TYPE:	Select "All Files"
-# FILE NAME:	"NeverSink.filter" (Without the ")
-# SAVE LOCATION:	C:/Users/Documents/My Games/Path of Exile
-# ENCODING (if available):	ANSI
-# INGAME: Escape -> Options -> UI -> Scroll down -> Select NeverSink.filter
-#
-# IF YOU CAN'T SEE THE FILTER, YOU EITHER SAVED THE FILE IN THE WRONG FOLDER OR FAILED TO GIVE IT THE .filter FILE TYPE!
-# IF YOUR ITEMS DISAPPEAR AFTER A WHILE CLICK "Z"
-# IF YOU CAN'T PICK UP ANY ITEMS, YOU LIKELY CHANGED THE "item select key" WHILE SCROLLING DOWN
-#
-#---------------------------------------------------------------------------------------------------------------
-# If you want to learn more about the syntax of item filters:
-# http://pathofexile.gamepedia.com/Item_filter_guide
-#---------------------------------------------------------------------------------------------------------------
-# DESIGN GOALS:
-#---------------------------------------------------------------------------------------------------------------
-# - This setup is designed to assist players during all stages of path of exile gameplay (Leveling AND Endgame).
-# - Highlight and notify players when worthwhile items drop
-# - Use intuitive colors, without breaking the PoE feeling and immersion much. Don't go overboard on colors!
-# - Provide light, scaling filtering during levelling
-# - Provide comprehensive and in-depth filtering during endgame play
-# - Provide evaluation help for high level rares based on criteria such as droplevel, itemlevel, item size, popularity and type. Helps you prioritize your pickups, while still showing everything!
-# - Highlight recipe material (Regal, Chromatics, Glassblowers, Jewelers) and crafting bases
-# - Easy to use setup
-#---------------------------------------------------------------------------------------------------------------
-#COLORS:
-#Most colors remain the same, I want the filter to be very intuitive
-#However, some improvements are implemented to improve your general efficiency
-#1) Grey background items are usually vendor recipe material, such as:
-#Chrom-Recipe, 6S, Chisel Recipe, Bauble Recipe.
-#2) Starting with ilvl 65 rares will be split into 4 categories:
-# Good (green BG), OK (regular BG), Bad (red BG) and excellent (green BG+green Border)
-# Good rares are high tier bases, less clunky and usually worth checking
-# Regular rares might end up being quite good, but usually are too clunky/average to be sellable
-# Bad rares are low level bases that are usually pretty horrible and are only displayed for alt/alch shard purposes
-# Excellent rares are rare rings/belts/amulets and jewels
-#3) In addition 75+ rares will have a darker textcolor in order to display their viability for the regal recipe
-#4) Orange border items are crafting materials - assorted 75+ items (mostly jewelry).
-#5) Strong large orange border items are assorted 83-84 items suitable for endgame crafting
-#6) Green border items are chancing bases.
-#7) Higher tier currency has a different appearance to improve drop detection/priorization.
-#8) Top tier items have a very distinctive appearance (opaqua white background with a strong color-border/text + large size)
-#You usually will find those items every 10++ hours of endgame gameplay. Don't worry it won't clutter your screen
-#9) Divination cards have a different appearance. (purple/pink themed)
-#10) Maps, currency, uniues and divination cards have tier lists - better items will be larger/brighter
-#---------------------------------------------------------------------------------------------------------------
-# LOOKUP AND QUICKJUMP TABLE
-#---------------------------------------------------------------------------------------------------------------
-# Select one of the strings below and use the search function
-# To jump to the section in the document
-# (also use Notepad++ as a edit tool if you're not using it already)
-#
-# ALPHA # GLOBAL OVERRIDE - ADD YOUR OWN RULES THAT WILL OVERRIDE THE OTHERS HERE
-# ALPHA-a # Talisman league!
-# 0000 # UTILITY AND JUST-IN-CASE
-# 0001 # LABYRINTH MATERIAL
-# 0100 # TOP TIER RARITY
-# 0200 # UNIQUES AND MAPS
-# 0201 # UNIQUE TIER LIST
-# 0202 # MAP TIER LIST
-# 0203 # MAP FRAGMENTS
-# 0300 # CURRENCY
-# 0301 # TOP TIER: DIVINE, EXALTED
-# 0302 # HIGH TIER: FROM ALCHEMY TO REGAL
-# 0303 # MEDIUM-LOW ORBS
-# 0304 # BOTTOM TIER: LOW ORB VARIATIONS
-# 0305 # DIVINATION CARD TIER LIST
-# 0306 # REST
-# 0400 # SOCKET/LINK BASED stuff
-# 0500 # SKILL GEMS
-# 0600 # RARE ITEM HIGHLIGHTING
-# 060a # RARES SUITABLE FOR ENDGAME CRAFTING
-# 060b # RARE RINGS, AMULETS, JEWELS, BELTS
-# 060c # DROP LEVEL 69+ ITEMS ARE ALWAYS PRIORITIZED RARES
-# 0601 # RARE DAGGERS
-# 0602 # RARE CLAWS
-# 0603 # RARE WANDS
-# 0604 # RARE SWORDS
-# 0605 # RARE AXES&MACES (1H)
-# 0606 # RARE SCEPTRES
-# 0607 # RARE STAVES
-# 0608 # RARE TWO HAND SWORDS + MACES + AXES
-# 0609 # RARE BOWS
-# 0610 # RARE QUIVERS
-# 0611 # RARE GLOVES, HELMETS, BOOTS
-# 0612 # RARE SHIELDS
-# 0613 # RARE BODY ARMOR
-# 0614 # RARES - LEVELING SPECIFIC RULES
-# 0615 # RARES - REMAINING RULES
-# 0700 # NORMAL AND MAGIC ITEM RULES
-# 0701 # 83+ ITEM CRAFTING
-# 0702 # CHROMATIC ORB RECIPE ITEMS
-# 0703 # CHANCE ORB BASES - ADD YOUR ITEMS HERE
-# 0704 # HIGH LEVEL WHITE RINGS/AMULETS FOR ALCHING
-# 0705 # MAGIC RINGS, AMULETS, BELTS
-# 0706 # MAGIC JEWELS
-# 0707 # CHISEL RECIPE ITEMS
-# 0708 # HIGH LEVEL 4+ LINKED ITEMS
-# 0709 # TOP BASES FOR CRAFTING
-# 0710 # MARAKETH WEAPONS
-# 0711 # PRE-ENDGAME 20% QUALITY ITEMS
-# 0712 # ANIMATE WEAPON SCRIPT (DISABLED)
-# 0800 # FLASKS
-# 0801 # HIDE OUTDATED FLASKS
-# 0802 # HIDE NON-QUALITY RANDOM FLASK DROPS IN MAPS
-# 0803 # FLASKS - Hybrid Flasks (Normal)
-# 0804 # FLASKS - Hybrid Flasks (Magic)
-# 0805 # FLASKS - HIGHLIGHT NEW NORMAL FLASKS (Kudos to Antnee)
-# 0806 # FLASKS - HIGHLIGHT NEW MAGIC FLASKS (Kudos to Antnee)
-# 0807 # SHOW WHATEVER FLASKS REMAIN
-# 0900 # LEVELING
-# 0901 # LEVELING HIGHLIGHT JEWELRY
-# 0902 # HIGHLIGHT LEVELING SPECIFIC ITEMS
-# 0903 # HIGHLIGHT LEVELING LINKED GEAR
-# 0904 # LEVELING WHITE/MAGIC ITEM PROGRESSION
-# 0905 # LEVELING GENERAL RULES
-# 5000 # TEMP AND WIP ENTRIES
-# 5001 # WARBAND MODS - DEACTIVATED
-# OMEGA # ADDITIONAL RULES - ADD YOUR OWN RULES THAT WON'T OVERRIDE THE OTHER RULES
-# XXXX # HIDE THE REST THEN FAILSAFE DISPLAY
-#
-#---------------------------------------------------------------------------------------------------------------
-# STYLE DATA FOR EASY SEARCH AND REPLACE
-#---------------------------------------------------------------------------------------------------------------
-#
-###GENERIC BORDER###
-#	SetBorderColor 0 0 0
-#
-###TALISMAN STYLE###
-#	SetBorderColor 109 200 130 255
-#
-###TOP RARITY STYLE###
-#	SetBackgroundColor 255 255 255 255
-#
-###MEDIUM RARITY UNIQUE BG###
-#	SetBackgroundColor 175 96 37 255
-#
-###HIGH CURRENCY STYLE###
-#	SetBackgroundColor 213 159 15
-#
-###MEDIUM CURRENCY STYLE###
-#	SetTextColor 190 178 135 255
-#
-###DIVINATION CARD TIERS###
-#	T1:	SetTextColor 255 0 175
-#	T2:	SetBackgroundColor 235 15 200
-#	T3: SetBackgroundColor 220 35 225
-#	T4:	SetBackgroundColor 200 50 250
-#	T5:	SetBackgroundColor 190 65 255
-#
-###83/84 CRAFTING BORDER###
-#	SetBorderColor 255 255 0 255
-#
-###REGAL RECIPE RARE INDICATOR###
-#	SetTextColor 255 190 0
-#
-###EXCEPTIONAL RARE INDICATOR###
-#	SetBorderColor 25 180 25
-#
-###GOOD RARE INDICATOR###
-#	SetBorderColor 30 90 45 230
-#
-###BAD RARE INDICATOR###
-#	SetBackgroundColor 120 20 20 150
-#
-###UTILITY/VENDOR INDICATOR###
-#	SetBackgroundColor 75 75 75
-#
-###ALCHEMY/LOWCRAFT INDICATOR###
-#	SetBorderColor 255 190 0 150
-#
-###LOW SIZE CHROM RECIPE INDICATOR###
-#	SetBorderColor 100 100 100
-#
-###MAGIC JEWEL BACKGROUND
-#	SetBorderColor 0 150 200
-#
-###CHANCE ORB ITEM INDICATOR###
-#	SetBorderColor 0 150 0 150
-#
-###ANIMATE WEAPON MODE###
-#	SetTextColor 150 0 0
-#	SetBorderColor 150 0 0
-#
-###PRIORITY MAGIC ITEMS (leveling+flasks)###
-#	SetTextColor 100 100 255
-#
-###HIDDEN ITEMS: normal
-#	SetBackgroundColor 0 0 0 100
-#
-###HIDDEN ITEMS: rare
-#	SetBackgroundColor 0 0 0 150
-#
-#---------------------------------------------------------------------------------------------------------------
-# SOUND DATA FOR EASY SEARCH AND REPLACE
-#---------------------------------------------------------------------------------------------------------------
-# Some new entries are not yet added to the list!
-#
-#The filter only uses 3 sounds:
-#
-#PlayAlertSound 6 300	high tier drops (all uniques, high orbs/cards/5-6links, high currency, fishing rods, 20% gems...)
-#PlayAlertSound 1 300	medium tier drops (divination cards, orbs from alch to gcps)
-#PlayAlertSound 4 300	map drops
-#
-#You'll quickly learn the 3 sounds while playing and will be able to recognize offscreen drops!
-#
-#
-#---------------------------------------------------------------------------------------------------------------
-# SCRIPT by NeverSink ( the-dude- in reddit)
-#---------------------------------------------------------------------------------------------------------------
-#
-#---------------------------------------------------------------------------------------------------------------
-# Section: ALPHA # GLOBAL OVERRIDE - ADD YOUR OWN RULES THAT WILL OVERRIDE THE OTHERS HERE
-#---------------------------------------------------------------------------------------------------------------
-#
-#---------------------------------------------------------------------------------------------------------------
-# Section: ALPHA-a # Talisman league!
-#---------------------------------------------------------------------------------------------------------------
-# !!!FILTER CODE START!!!
+#===============================================================================================================
+# NeverSink's Indepth Loot Filter - for Path of Exile
+#===============================================================================================================
+# VERSION:		4.63
+# TYPE:			1-REGULAR
+# STYLE:		NORMAL
+# AUTHOR:		NeverSink
+# BUILDNOTES:	Filter improved with NeverSink's Filterpolish tool (v0.3)
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 0 255 150 255
-	SetBackgroundColor 0 75 75 255
-	SetFontSize 42
-	PlayAlertSound 6 300
-	Rarity Unique
-	ItemLevel > 78
+#------------------------------------
+# LINKS TO THE LATEST VERSION / REPOSITORY:
+#------------------------------------
+#
+# GET THE LATEST VERSION ON: 	https://github.com/NeverSinkDev/NeverSink-Filter
+# DETAILED EXPLANATIONS: 		https://goo.gl/oQn4EN
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 0 255 150 255
-	SetBackgroundColor 0 75 75 255
-	SetFontSize 40
-	PlayAlertSound 1 300
-	Rarity Rare
-	ItemLevel > 78
+#------------------------------------
+# INSTALLATION / UPDATE :
+#------------------------------------
+#
+# 0) Please update this filter from my GitHub before each PoE league (at least every 3 month)
+# 1) Paste this file into the following folder: %userprofile%/Documents/My Games/Path of Exile
+# 2) INGAME: Escape -> Options -> UI -> Scroll down -> Select the filter from the Dropdown box
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 0 255 150 255
-	SetBackgroundColor 0 75 75 255
-	SetFontSize 38
-	Rarity Magic
-	ItemLevel > 78
+#------------------------------------
+# CONTACT - if you want to get notifications about updates or just get in touch:
+#------------------------------------
+# PLEASE READ THE FAQ ON https://goo.gl/oQn4EN BEFORE ASKING QUESTIONS
+#
+# REDDIT:  NeverSinkDev
+# GITHUB:  NeverSinkDev
+# EMAIL :  NeverSinkGaming-at-gmail.com
+# TWITTER: @NeverSinkGaming
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 0 255 150 255
-	SetBackgroundColor 0 75 75 255
-	SetFontSize 36
-	Rarity Normal
-	ItemLevel > 78
+#===============================================================================================================
+#[WELCOME] TABLE OF CONTENTS + QUICKJUMP TABLE
+#===============================================================================================================
+#
+# [[0100]] OVERRIDE AREA 1 - Override ALL rules here (includes 6links etc, be careful)
+# [[0200]] Recipes, Magic and Normal items (endgame!)
+#   [0201] 6-Linked items
+#   [0202] 5-Linked items
+#   [0203] 6-Socket Items
+#   [0204] Exclusive bases: Atlas bases, talismans
+#   [0205] Corrupted Amulets
+#   [0206] Chancing items
+#   [0207] Add your own crafting rules here
+#   [0208] 83/84+ Endgame crafting rules
+#   [0209] 60+ Crafting rules for 60++ trinkets
+#   [0210] Warband items
+#   [0211] Remaining crafting rules - add your own bases here!
+#   [0212] Chisel recipe items
+#   [0213] Fishing Rod
+#   [0214] SRS Crude Bow
+#   [0215] Chromatic recipe items ("RGB Recipe")
+#   [0216] Endgame-start 4-links
+#   [0217] Animate Weapon script - deactivated by default
+#   [0218] W-soc offhand weapons
+#   [0219] Sacrificial Garb
+# [[0300]] HIDE LAYER 1 - MAGIC AND NORMAL ITEMS
+# [[0400]] Currency - PART 1 - Common currency
+# [[0500]] OVERRIDE AREA 2 - Override the default rare rulesets here
+# [[0600]] RARE ITEMS (ENDGAME)
+#   [0601] Rare Atlas bases (84+)
+#   [0602] Rare crafting bases
+#   [0603] T1 rare items
+#   [0604] T1.5 rare items
+#   [0605] T2 rare items
+#   [0606] Breach Rings
+#   [0607] Amulets, Jewels, Rings, Belts
+#   [0608] 1H Daggers
+#   [0609] 1H Claws
+#   [0610] 1H Wands
+#   [0611] 1H Swords and Foils
+#   [0612] 1H Axes and Maces
+#   [0613] 1H Sceptres
+#   [0614] 2H Staves
+#   [0615] 2H Swords, Axes, Maces
+#   [0616] 2H Bows
+#   [0617] AR: Gloves, Boots, Helmets
+#   [0618] AR: Body Armors
+#   [0619] OH: Shields
+#   [0620] OH: Quivers
+#   [0621] Rare endgame items - remaining rules
+# [[0700]] HIDE LAYER 2 - RARE ITEMS (65+ ONLY FOR NON-REGULAR VERSIONS)
+# [[0800]] OVERRIDE AREA 3 - Override Map, Gem and Flask drops here
+# [[0900]] Gems
+#   [0901] Value gems
+#   [0902] Other gems
+# [[1000]] FLASKS (Endgame rules)
+# [[1100]] HIDE LAYER 3: Random Endgame Flasks
+# [[1200]] Maps, fragments and labyrinth items
+#   [1201] Unique Maps
+#   [1202] Labyrinth items, Offerings
+#   [1203] Top tier maps (T15-16)
+#   [1204] High tier maps(T11-14)
+#   [1205] Mid tier maps (T6-10)
+#   [1206] Low tier maps (T1-T5)
+#   [1207] Map fragments
+# [[1300]] Currency - PART 2 - Rare currency
+#   [1301] Regular Rare Currency
+#   [1302] Top Currency
+#   [1303] Essence Tier List
+#   [1304] Special items
+# [[1400]] Currency - PART 3 - Divination cards (yes the strange sorting is intended)
+#   [1401] Exceptions to prevent ident. mistakes
+#   [1402] T1 - Top tier cards
+#   [1403] T2 - Great cards
+#   [1404] T3 - Decent cards
+#   [1405] T5 - Format trash tier cards... before
+#   [1406] T4 - ...showing the remaining cards
+# [[1500]] Currency - PART 4 - remaining items
+# [[1600]] Leaguestones - Tierlists
+# [[1700]] Uniques!
+#   [1701] Exceptions
+#   [1702] Tier 1 uniques
+#   [1703] Tier 2 uniques
+#   [1704] Multi-Unique bases.
+#   [1705] Prophecy-Material Uniques
+#   [1706] Random Uniques
+# [[1800]] Exceptions - Quest Items etc.
+# [[1900]] OVERRIDE AREA 4 - Insert your custom leveling adjustments here
+# [[2000]] LEVELING - Flasks
+#   [2001] Hide outdated flasks
+#   [2002] Hybrid flasks (normal)
+#   [2003] Hybrid flasks (magic)
+#   [2004] Life/Mana Flask - Normal (Kudos to Antnee)
+#   [2005] Life/Mana Flask - Magic (Kudos to Antnee)
+#   [2006] Show remaining flasks
+# [[2100]] LEVELING - RARES
+#   [2101] Leveling rares - tier list
+#   [2102] Leveling rares - remaining rules
+# [[2200]] LEVELING - Useful items
+#   [2201] Leveling RGB Exceptions 3L
+#   [2202] Jewellery & Helpful leveling and racing gear
+#   [2203] Caster weapons
+#   [2204] Linked gear
+#   [2205] 20% quality items for those strange people who want them
+# [[2300]] Levelling - normal and magic item progression
+#   [2301] Normal items - First 12 levels - exceptions
+#   [2302] Normal weapons - progression
+#   [2303] Magic items - progression
+# [[2400]] HIDE LAYER 5 - Remaining Items
+# [[2500]] CATCHALL - if you see pink items - send me a mail please - should never happen
+# [[2600]] Special thanks to!
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 109 200 130 255
-	SetBackgroundColor 0 0 0 255
-	SetFontSize 42
-	PlayAlertSound 6 300
-	Rarity Unique
+#===============================================================================================================
+# [[0100]] OVERRIDE AREA 1 - Override ALL rules here (includes 6links etc, be careful)
+#===============================================================================================================
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 109 200 130 255
-	SetBackgroundColor 0 0 0 255
-	SetFontSize 40
-	PlayAlertSound 1 300
-	Rarity Rare
+#===============================================================================================================
+# [[0200]] Recipes, Magic and Normal items (endgame!)
+#===============================================================================================================
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 109 200 130 255
-	SetBackgroundColor 0 0 0 255
-	SetFontSize 38
-	Rarity Magic
+#------------------------------------
+#   [0201] 6-Linked items
+#------------------------------------
+# Extremely rare, valuable drops. At worst a divine orb.
 
-Show
-	BaseType "Talisman"
-	SetBorderColor 109 200 130 255
-	SetBackgroundColor 0 0 0 255
-	SetFontSize 36
-	Rarity Normal
-
-#---------------------------------------------------------------------------------------------------------------
-# Section: 0000 # UTILITY AND JUST-IN-CASE
-#---------------------------------------------------------------------------------------------------------------
-
-Show
-	Class Microtransactions
-
-#------------------------------------------------------------------------
-# Section: 0001 # LABYRINTH MATERIAL
-#------------------------------------------------------------------------	
-	
-Show
-	Class Quest Items
-	SetFontSize 40
-	SetBorderColor 74 230 58
-
-Show
-	BaseType "Treasure Key" "Golden Key" "Silver Key" "Bane of the Loyal" "Orb of Elemental Essence" "Portal Shredder" "Rod of Detonation" "Sand of Eternity" "Heart of the Gargoyle" "Cube Of Absorption" "Cogs of Disruption"
-	SetFontSize 40
-	SetBorderColor 74 230 58
-	SetTextColor 74 230 58
-
-#------------------------------------------------------------------------
-# Section: 0100 # TOP TIER RARITY
-#------------------------------------------------------------------------
-
-Show
-	Class "Fishing Rod"
-	SetTextColor 255 0 0 255
-	SetBorderColor 255 0 0 255
-	SetBackgroundColor 255 255 255 255
+Show # 6-Links
+	LinkedSockets 6
+	Rarity <= Rare
 	SetFontSize 45
-	PlayAlertSound 6 300
+	SetTextColor 255 0 0 255             # TEXTCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBorderColor 255 0 0 255           # BORDERCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-#Exception for tabula
+#------------------------------------
+#   [0202] 5-Linked items
+#------------------------------------
+# Very useful at the start of the league. Otherwise often trash. Still, highlight material.
+# There’s a lot of exceptions we can introduce here, such as 6S, high value bases, but this
+# Is a rare occurrence, so we won’t be doing it for performance reasons.
+
+Show # 5-Links
+	LinkedSockets 5
+	Rarity < Unique
+	SetFontSize 40
+	SetBorderColor 0 255 255             # BORDERCOLOR:	 Cosmetic: 5L
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [0203] 6-Socket Items
+#------------------------------------
+# Can be sold for 7 jeweller orbs. We also highlight the ilvl83/84 ones that are OK for crafting.
+# Chances are high that people will want to buy those.
+
+Show # 6-Sockets %TB-6S-Rare-Armors
+	Sockets 6
+	BaseType "Assassin's Garb" "Glorious Plate" "Astral Plate" "Vaal Regalia" "Zodiac Leather"
+	Rarity <= Rare
+	ItemLevel >= 84
+	SetFontSize 43
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # 6-Sockets %TB-6S-Rare-Weapons
+	Sockets 6
+	BaseType "Harbinger Bow" "Vaal Axe" "Coronal Maul" "Exquisite Blade"
+	Rarity <= Rare
+	ItemLevel >= 83
+	SetFontSize 42
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # 6-Sockets
+	Sockets 6
+	Rarity = Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # 6-Sockets
+	Sockets 6
+	Rarity <= Rare
+	SetFontSize 40
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [0204] Exclusive bases: Atlas bases, talismans
+#------------------------------------
+# These bases are valuable crafting due to their rarity and strong implicit.
+
+Show #$crafting %TB-Top-Atlas-Bases
+	BaseType "Steel Ring" "Opal Ring" "Crystal Belt"
+	Rarity < Rare
+	ItemLevel >= 84
+	SetFontSize 45
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show #$crafting %TB-Top-Atlas-Bases
+	BaseType "Steel Ring" "Opal Ring" "Crystal Belt"
+	Rarity < Rare
+	SetFontSize 42
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show #$crafting %TB-Atlas-Bases
+	BaseType "Blue Pearl Amulet" "Marble Amulet" "Vanguard Belt" "Bone Helmet" "Two-Toned Boots" "Spiked Gloves" "Gripped Gloves" "Fingerless Silk Gloves"
+	Rarity < Rare
+	ItemLevel >= 84
+	SetFontSize 42
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+
+Show #$crafting %TB-Atlas-Bases %D4
+	BaseType "Blue Pearl Amulet" "Marble Amulet" "Vanguard Belt" "Bone Helmet" "Two-Toned Boots" "Spiked Gloves" "Gripped Gloves" "Fingerless Silk Gloves"
+	Rarity < Rare
+	SetFontSize 38
+	SetBorderColor 255 125 0 200         # BORDERCOLOR:	 T2 Atlas bases
+
+Show # %TB-Talisman
+	Class Amulets
+	BaseType "Talisman"
+	Rarity < Unique
+	SetFontSize 40
+	SetBorderColor 109 200 130 255       # BORDERCOLOR:	 Cosmetic: Talisman
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [0205] Corrupted Amulets
+#------------------------------------
+# Corrupted amulets for rare lab shrines (to turn them rare)
+
+Show #$lead to gold bases %TC-Corrupted-Bases
+	Corrupted True
+	Class Amulet Belt
+	Rarity = Normal
+	SetFontSize 34
+	SetBorderColor 129 15 213 200        # BORDERCOLOR:	 Warband Item
+
+#------------------------------------
+#   [0206] Chancing items
+#------------------------------------
+# You can add your own items here. The items in this section have a dropsound
+
+# LEGACY UNIQUES: THESE UNIQUES CAN ONLY BE CHANCED IN THE CORRECT ZANA-LEAGUE MODS
+# Agate Amulet - ANARCHY ONLY - can be chance to voll's in anarchy maps
+# Leather belt - NEMESIS only - can be chanced into a headhunter belt!
+
+# EXAMPLE OF NON LEGACY UNIQUES:
+# Prophecy wand - Void Battery
+# Judgement Staff - Hegemony's/Pledge of Hands
+
+# TO ADD AN ITEM ATTACH IT'S NAME TO THE BASAETYPE'S IN ONE OF THE 2 ENTRIES BELOW.
+# Example, to add Agate amulet:
+# BaseType "Sorcerer Boots" "Agate Amulet"
+
+Show #$chancing (with sound) %TB-T1-Chancing %D4
+	BaseType "Sorcerer Boots"
+	Rarity Normal
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 0 210 0 210           # BORDERCOLOR:	 T1 Chancing
+	PlayAlertSound 7 300                 # DROPSOUND:	 T1 chancing items
+
+Show #$chancing (no sound) %TB-T2-Chancing %D4
+	BaseType "Leather Belt"
+	Rarity Normal
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 0 150 0 150           # BORDERCOLOR:	 T2 Chancing
+
+Show #$chancing (no sound) %TB-T2-Chancing %D1
+	BaseType "Occultist's Vestment" "Prophecy Wand" "Goathide Boots"
+	Rarity Normal
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 0 150 0 150           # BORDERCOLOR:	 T2 Chancing
+
+#------------------------------------
+#   [0207] Add your own crafting rules here
+#------------------------------------
+# Please use ItemLevel >= 65 if you DON'T want your rules to affect levelling progression.
+# Example: To highlight all white "Vaal Claw" and "Gemini Claw" in the endgame, uncomment the following section (remove the '#')
+
+# Show
+# BaseType "Gemini Claw" "Vaal Claw"
+# ItemLevel >= 65
+# Rarity = Normal
+# SetBorderColor 0 255 255 255
+# SetFontSize 40
+
+#------------------------------------
+#   [0208] 83/84+ Endgame crafting rules
+#------------------------------------
+# These entries are non-exclusive bases that are popular for crafting
+
+Show #$crafting %TB-T1-Crafting
+	BaseType "Onyx" "Diamond Ring" "Prismatic" "Titanium Spirit Shield" "Hubris Circlet" "Sorcerer Boots" "Sorcerer Gloves" "Vaal Regalia" "Two-Stone"
+	Rarity < Rare
+	ItemLevel >= 84
+	SetFontSize 40
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+
+Show #$crafting %TB-T2-Trinket-Bases %D3
+	Class Rings Amulet Belts
+	BaseType "Ruby" "Sapphire" "Topaz" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash" "Chain Belt"
+	Rarity < Rare
+	ItemLevel >= 84
+	SetFontSize 38
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+
+Show #$crafting %TB-T2-Crafting-84 %D2
+	BaseType "Profane Wand" "Sambar Sceptre" "Void Sceptre" "Imbued Wand" "Saintly Chainmail" "Harmonic Spirit Shield" "Fossilised Spirit Shield" "Titan Gauntlets" "Slink Gloves" "Royal Burgonet" "Lion Pelt" "Titan Greaves" "Slink Boots" "Kris"
+	Rarity < Rare
+	ItemLevel >= 84
+	SetFontSize 36
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+
+Show #$crafting %TB-T2-Crafting-83 %D2
+	BaseType "Vaal Axe" "Coronal Maul" "Exquisite Blade" "Fleshripper" "Harbinger Bow" "Gemini Claw" "Ambusher" "Siege Axe" "Harpy Rapier" "Demon Dagger" "Skean" "Spiraled Foil" "Jewelled Foil"
+	Rarity < Rare
+	ItemLevel >= 83
+	SetFontSize 36
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+
+#------------------------------------
+#   [0209] 60+ Crafting rules for 60++ trinkets
+#------------------------------------
+# This section handles the crafting bases for the entry level endgame
+
+Show #$trinkets, jewels %H4
+	Class Jewel
+	Rarity <= Magic
+	SetFontSize 36
+	SetTextColor 0 100 255               # TEXTCOLOR:	 Jewel: Magic
+	SetBorderColor 0 75 250              # BORDERCOLOR:	 Cosmetic: Magic Jewels
+	SetBackgroundColor 0 20 40 255       # BACKGROUND:	 Jewel: Magic
+
+Show #$crafting %TB-T1-Trinket-Bases %D2
+	Class Rings Amulet Belts
+	BaseType "Onyx" "Two-Stone" "Diamond" "Prismatic"
+	Rarity Normal
+	ItemLevel >= 75
+	SetFontSize 34
+	SetBorderColor 255 190 0 150         # BORDERCOLOR:	 Crafting: Regal trinkets
+
+Show #$crafting %TB-T2-Trinket-Bases %D1
+	Class Rings Amulet Belts
+	BaseType "Ruby" "Sapphire" "Topaz" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash" "Chain Belt"
+	Rarity Normal
+	ItemLevel >= 75
+	SetFontSize 32
+	SetBorderColor 255 190 0 150         # BORDERCOLOR:	 Crafting: Regal trinkets
+
+Show #$crafting %TB-T1-Trinket-Bases %D2
+	Class Rings Amulet Belts
+	BaseType "Onyx" "Two-Stone" "Diamond" "Prismatic"
+	Rarity Normal
+	ItemLevel >= 60
+	ItemLevel < 75
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+Show #$crafting %TB-T2-Trinket-Bases %D1
+	Class Rings Amulet Belts
+	BaseType "Ruby" "Sapphire" "Topaz" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash" "Chain Belt"
+	Rarity Normal
+	ItemLevel >= 60
+	ItemLevel < 75
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+Show #$trinkets %D1
+	Class Rings Amulets Belts
+	Rarity Magic
+	ItemLevel >= 60
+	SetFontSize 28
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#------------------------------------
+#   [0210] Warband items
+#------------------------------------
+# This section handles warband items, with special warband mods.
+# We're showing identified items of the right level, this may cause the filter to highlight a few other items
+# If you want to see the other items: click alt.
+
+Show # %D2 %TC-Ele-Warband-Bases
+	Corrupted False
+	Identified True
+	Class "Helmets" "Boots"
+	Rarity Magic
+	ItemLevel > 68
+	ItemLevel = 82
+	SetFontSize 34
+	SetBorderColor 129 15 213 200        # BORDERCOLOR:	 Warband Item
+
+Show # %D2 %TC-Chaos-Warband-Bases
+	Corrupted False
+	Identified True
+	Class "Daggers" "Wands" "Sceptres"
+	Rarity Magic
+	ItemLevel > 68
+	ItemLevel = 84
+	SetFontSize 34
+	SetBorderColor 129 15 213 200        # BORDERCOLOR:	 Warband Item
+
+Hide # %TC-Ele-Warband-Bases
+	Corrupted False
+	Identified True
+	Class "Helmets" "Boots"
+	Rarity Magic
+	ItemLevel > 68
+	SetFontSize 34
+	SetBorderColor 129 15 213 200        # BORDERCOLOR:	 Warband Item
+
+Hide # %TC-Chaos-Warband-Bases
+	Corrupted False
+	Identified True
+	Class "Daggers" "Wands" "Sceptres"
+	Rarity Magic
+	ItemLevel > 68
+	SetFontSize 34
+	SetBorderColor 129 15 213 200        # BORDERCOLOR:	 Warband Item
+
+#------------------------------------
+#   [0211] Remaining crafting rules - add your own bases here!
+#------------------------------------
+# This section handles additional crafting bases.
+
+Show #$crafting, regal %TB-Individual-And-SSF-Craft-Bases %D2
+	BaseType "Hubris Circlet" "Vaal Regalia" "Harbinger Bow"
+	Rarity < Rare
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+#------------------------------------
+#   [0212] Chisel recipe items
+#------------------------------------
+# Chisel Recipe: You can sell a 20% hammer + random map for 1 chisel
+
+Show #$chisel, recipes %TB-Gavels %D3
+	Quality = 20
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Magic
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$chisel, recipes %TB-Gavels %D3
+	Quality = 20
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Normal
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$chisel, recipes %TB-Gavels %D3
+	Quality > 17
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Magic
+	SetFontSize 36
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$chisel, recipes %TB-Gavels %D3
+	Quality > 14
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Normal
+	SetFontSize 36
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$chisel, recipes %TB-Gavels %D2
+	Quality > 11
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Magic
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$chisel, recipes %TB-Gavels %D2
+	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
+	Rarity Normal
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+#------------------------------------
+#   [0213] Fishing Rod
+#------------------------------------
+# Give a man a fish and he won't be hungy for a day, teach a man to fish and GGG will ban you for disclosing fishing secrets.
+
+Show # %TC-Secret
+	Class "Fishing Rod"
+	SetFontSize 45
+	SetTextColor 255 0 0 255             # TEXTCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBorderColor 255 0 0 255           # BORDERCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+#------------------------------------
+#   [0214] SRS Crude Bow
+#------------------------------------
+# Crude bows are a meta weapon for SRS summoners, so we'll highlight them no matter the rarity post level 49
+
+Show #$meta %TB-Low-BaseType-Crafting %D4
+	BaseType "Crude Bow"
+	Rarity <= Rare
+	ItemLevel >= 50
+	SetFontSize 42
+	SetBorderColor 25 235 25 255         # BORDERCOLOR:	 Rares - Size - Tiny, special base
+
+#------------------------------------
+#   [0215] Chromatic recipe items ("RGB Recipe")
+#------------------------------------
+# These items have a RGB link and sell for a chromatic orb each.
+
+Show #$rgb, small %H3
+	SocketGroup RGB
+	Width <= 2
+	Height <= 2
+	Rarity < Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$rgb, small %H3
+	SocketGroup RGB
+	Width <= 1
+	Height <= 3
+	Rarity < Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$rgb, bulky %H1
+	SocketGroup RGB
+	Width >= 2
+	Height >= 4
+	Rarity < Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$rgb %H2
+	SocketGroup RGB
+	Rarity < Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+#------------------------------------
+#   [0216] Endgame-start 4-links
+#------------------------------------
+
+Show #$nonmf %D1
+	LinkedSockets >= 4
+	DropLevel >= 65
+	Class "Boots" "Gloves" "Body Armour" "Helmets"
+	Rarity < Rare
+	ItemLevel < 72
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#------------------------------------
+#   [0217] Animate Weapon script - deactivated by default
+#------------------------------------
+# UNCOMMENT THIS SCRIPT TO MAKE IT WORK (remove the # in front of the next 7 lines)
+
+#Show #$animate
+#	Class "One Hand" "Two Hand" "Staves" "Daggers" "Thrusting" "Sceptres" "Claws"
+#	Rarity Normal
+#	SetBackgroundColor 0 0 0 255
+#	SetTextColor 150 0 0 255
+#	SetBorderColor 150 0 0 255
+#	SetFontSize 20
+
+#Show #$animate, ranged
+#	Class "Bows" "Wands"
+#	Rarity Normal
+#	SetBackgroundColor 0 0 0 255
+#	SetTextColor 150 0 0 255
+#	SetBorderColor 150 0 0 255
+#	SetFontSize 20
+
+#Show #$animate, identified
+#	Class "One Hand" "Two Hand" "Staves" "Daggers" "Thrusting" "Sceptres" "Claws"
+#	Rarity Magic
+#	SetBackgroundColor 0 0 0 255
+#	SetTextColor 150 0 0 255
+#	SetBorderColor 150 0 0 255
+#	SetFontSize 20
+#	Identified True
+
+#Show #$animate, identified, ranged
+#	Class "Bows" "Wands"
+#	Rarity Magic
+#	SetBackgroundColor 0 0 0 255
+#	SetTextColor 150 0 0 255
+#	SetBorderColor 150 0 0 255
+#	SetFontSize 20
+#	Identified True
+
+#------------------------------------
+#   [0218] W-soc offhand weapons
+#------------------------------------
+# Useful for gem leveling.
+
+# Corrupted items with white sockets for offhand gem levelling.
+Show # %D3 %TC-Offslot-Gem-Leveling
+	Sockets >= 3
+	SocketGroup W
+	Class Wands Daggers One Hand Shields Thrusting Sceptre Claws
+	Rarity < Rare
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+#------------------------------------
+#   [0219] Sacrificial Garb
+#------------------------------------
+# Generally not useful, but so rare, that some people still might want to see it
+
+Show #$crafting, exception %TB-Special-AlwaysShow-Bases
+	BaseType "Sacrificial Garb"
+	Rarity <= Rare
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 0 150 0 150           # BORDERCOLOR:	 T2 Chancing
+
+#===============================================================================================================
+# [[0300]] HIDE LAYER 1 - MAGIC AND NORMAL ITEMS
+#===============================================================================================================
+
+Hide # Minimize junk instead of hiding (if "Show") %TC-Junkable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity < Rare
+	ItemLevel > 60
+	SetFontSize 18
+	SetBorderColor 0 0 0 100             # BORDERCOLOR:	 Cosmetic: Junk
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#===============================================================================================================
+# [[0400]] Currency - PART 1 - Common currency
+#===============================================================================================================
+# We'll keep this section up here to boost the performance.
+
+Show # %TB-Currency-T4
+	Class Currency
+	BaseType "Orb of Chance" "Orb of Alteration" "Chromatic Orb" "Jeweller's Orb"
+	SetFontSize 40
+	SetTextColor 210 178 135 255         # TEXTCOLOR:	 Low currency T1
+	SetBorderColor 213 159 100 200       # BORDERCOLOR:	 T1 LOW currency
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+
+Show # %H4 %TB-Currency-T5
+	Class Currency
+	BaseType "Orb of Transmutation" "Blacksmith's Whetstone" "Alchemy Shard"
+	SetFontSize 36
+	SetBorderColor 190 178 135 110       # BORDERCOLOR:	 T2 LOW currency
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+
+Show # %H3 %TB-Currency-T6
+	Class Currency
+	BaseType "Armourer's Scrap" "Orb of Augmentation" "Alteration Shard"
+	SetTextColor 170 158 130 220         # TEXTCOLOR:	 Low currency T3
+	SetBorderColor 60 50 30 255          # BORDERCOLOR:	 T3 LOW currency
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+
+Show # %H3 %TB-Currency-T7
+	Class Currency
+	BaseType "Portal Scroll" "Scroll of Wisdom"
+	SetTextColor 170 158 130 220         # TEXTCOLOR:	 Low currency T3
+	SetBorderColor 60 50 30 255          # BORDERCOLOR:	 T3 LOW currency
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+
+#===============================================================================================================
+# [[0500]] OVERRIDE AREA 2 - Override the default rare rulesets here
+#===============================================================================================================
+
+# Example: This section displays 20% quality rares (between lvl 60 and 74), it's disabled by default, remove
+# The #'s in front of the next lines to enable it and show the items with a Cyan border.
+
+# Show
+# Rarity Rare
+# Quality = 20
+# Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+# Rarity Rare
+# ItemLevel >= 60
+# ItemLevel < 75
+# SetFontSize 42
+# SetBorderColor 0 255 255 255         # BORDERCOLOR:	 Crafting: T1
+# SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#===============================================================================================================
+# [[0600]] RARE ITEMS (ENDGAME)
+#===============================================================================================================
+
+#------------------------------------
+#   [0601] Rare Atlas bases (84+)
+#------------------------------------
+
+Show #$crafting, egc, top %TB-Top-Atlas-Bases
+	BaseType "Steel Ring" "Opal Ring" "Crystal Belt"
+	Rarity Rare
+	ItemLevel >= 84
+	SetFontSize 44
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show #$crafting, egc, top %TB-Atlas-Bases
+	BaseType "Blue Pearl Amulet" "Marble Amulet" "Vanguard Belt" "Bone Helmet" "Two-Toned Boots" "Spiked Gloves" "Gripped Gloves" "Fingerless Silk Gloves"
+	Rarity Rare
+	ItemLevel >= 84
+	SetFontSize 44
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [0602] Rare crafting bases
+#------------------------------------
+
+Show #$topcrafting, ilvl84 %TB-T1-Crafting
+	BaseType "Onyx Amulet" "Diamond" "Prismatic" "Titanium Spirit Shield" "Hubris Circlet" "Sorcerer Boots" "Sorcerer Gloves" "Vaal Regalia" "Two-Stone"
+	Rarity Rare
+	ItemLevel >= 84
+	SetFontSize 42
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$topcrafting, ilvl84 %D2 %TB-T2-Crafting-84
+	BaseType "Profane Wand" "Sambar Sceptre" "Void Sceptre" "Imbued Wand" "Saintly Chainmail" "Harmonic Spirit Shield" "Fossilised Spirit Shield" "Titan Gauntlets" "Slink Gloves" "Royal Burgonet" "Lion Pelt" "Titan Greaves" "Slink Boots" "Kris"
+	Rarity Rare
+	ItemLevel >= 84
+	SetFontSize 38
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$topcrafting, ilvl84 %D4 %TB-T2-Crafting-Jwl
+	Class Rings Amulet Belts
+	BaseType "Ruby" "Sapphire" "Topaz" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash"
+	Rarity Rare
+	ItemLevel >= 84
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$topcrafting, ilvl83 %D2 %TB-T2-Crafting-83
+	BaseType "Vaal Axe" "Coronal Maul" "Exquisite Blade" "Fleshripper" "Harbinger Bow" "Gemini Claw" "Ambusher" "Siege Axe" "Harpy Rapier" "Demon Dagger" "Skean" "Spiraled Foil" "Jewelled Foil"
+	Rarity Rare
+	ItemLevel >= 83
+	SetFontSize 38
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 255 0 190         # BORDERCOLOR:	 Crafting: T2
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#------------------------------------
+#   [0603] T1 rare items
+#------------------------------------
+
+Show #$crafting, egc, top %TB-Top-Atlas-Bases
+	BaseType "Steel Ring" "Opal Ring" "Crystal Belt"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 42
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show #$crafting, egc, top %TB-Top-Atlas-Bases
+	BaseType "Steel Ring" "Opal Ring" "Crystal Belt"
+	Rarity Rare
+	SetFontSize 44
+	SetBorderColor 255 125 0 255         # BORDERCOLOR:	 T1 Atlas bases
+	SetBackgroundColor 100 75 0 255      # BACKGROUND:	 T1 Atlas bases
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show #$crafting, egc, top %TB-Atlas-Bases
+	BaseType "Blue Pearl Amulet" "Marble Amulet" "Vanguard Belt" "Bone Helmet" "Two-Toned Boots" "Spiked Gloves" "Gripped Gloves" "Fingerless Silk Gloves"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 255 125 0 200         # BORDERCOLOR:	 T2 Atlas bases
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$crafting, egc, top %TB-Atlas-Bases
+	BaseType "Blue Pearl Amulet" "Marble Amulet" "Vanguard Belt" "Bone Helmet" "Two-Toned Boots" "Spiked Gloves" "Gripped Gloves" "Fingerless Silk Gloves"
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 255 125 0 200         # BORDERCOLOR:	 T2 Atlas bases
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons, small %TB-RARE-T1-WepSmall
+	BaseType "Ambusher" "Platinum Kris" "Imbued Wand" "Skean" "Ezomyte Dagger"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons, small %TB-RARE-T1-WepSmall
+	BaseType "Ambusher" "Platinum Kris" "Imbued Wand" "Skean" "Ezomyte Dagger"
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, small %TB-RARE-T1-ArmSmall
+	BaseType "Hubris Circlet" "Sorcerer Boots" "Sorcerer Gloves" "Titanium Spirit Shield" "Harmonic Spirit Shield"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, small %TB-RARE-T1-ArmSmall
+	BaseType "Hubris Circlet" "Sorcerer Boots" "Sorcerer Gloves" "Titanium Spirit Shield" "Harmonic Spirit Shield"
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, bulky %TB-RARE-T1-Arm
+	BaseType "Vaal Regalia"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, bulky %TB-RARE-T1-Arm
+	BaseType "Vaal Regalia"
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#------------------------------------
+#   [0604] T1.5 rare items
+#------------------------------------
+
+Show #$great, armor, small %HB4 %TB-RARE-T1.5-Arm
+	BaseType "Titan Gauntlets" "Lion Pelt" "Slink Boots" "Titan Greaves" "Royal Burgonet" "Slink Gloves" "Arcanist Slippers" "Arcanist Gloves" "Mind Cage"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, small %HB4 %TB-RARE-T1.5-Arm
+	BaseType "Titan Gauntlets" "Lion Pelt" "Slink Boots" "Titan Greaves" "Royal Burgonet" "Slink Gloves" "Arcanist Slippers" "Arcanist Gloves" "Mind Cage"
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 210 210 210 255       # BORDERCOLOR:	 Rares - Size - Small (+Amazing basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#------------------------------------
+#   [0605] T2 rare items
+#------------------------------------
+
+Show #$great, weapons, small %HB3 %TB-RARE-T2-WepSmall
+	BaseType "Gemini Claw" "Tornado Wand" "Opal Wand" "Prophecy Wand" "Vaal Rapier" "Harpy Rapier" "Profane Wand" "Jewelled Foil" "Spiraled Foil" "Skean" "Kris" "Demon Dagger"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 180 180 180 255       # BORDERCOLOR:	 Rares - Size - Small (+Great basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons, small %HB3 %TB-RARE-T2-WepSmall
+	BaseType "Gemini Claw" "Tornado Wand" "Opal Wand" "Prophecy Wand" "Vaal Rapier" "Harpy Rapier" "Profane Wand" "Jewelled Foil" "Spiraled Foil" "Skean" "Kris" "Demon Dagger"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 180 180 180 255       # BORDERCOLOR:	 Rares - Size - Small (+Great basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons, bulky %HB3 %TB-RARE-T2-WepBig
+	BaseType "Vaal Axe" "Coronal Maul" "Harbinger Bow"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons, bulky %HB3 %TB-RARE-T1-WepBig
+	BaseType "Vaal Axe" "Coronal Maul" "Harbinger Bow"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons %HB3 %TB-RARE-T2-Wep
+	BaseType "Void Sceptre" "Sambar Sceptre"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, weapons %HB3 %TB-RARE-T2-Wep
+	BaseType "Void Sceptre" "Sambar Sceptre"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, small %HB3 %TB-RARE-T2-ArmSmall
+	BaseType "Crusader Boots" "Nightmare Bascinet" "Murder Boots" "Dragonscale Boots" "Vaal Greaves" "Stealth Boots" "Murder Mitts" "Dragonscale Gauntlets" "Crusader Gloves" "Vaal Gauntlets" "Praetor Crown" "Deicide Mask" "Royal Burgonet" "Sinner Tricorne" "Vaal Spirit Shield" "Conjurer Boots" "Conjurer Gloves" "Solaris Circlet"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 180 180 180 255       # BORDERCOLOR:	 Rares - Size - Small (+Great basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, small %HB3 %TB-RARE-T2-ArmSmall
+	BaseType "Crusader Boots" "Nightmare Bascinet" "Murder Boots" "Dragonscale Boots" "Vaal Greaves" "Stealth Boots" "Murder Mitts" "Dragonscale Gauntlets" "Crusader Gloves" "Vaal Gauntlets" "Praetor Crown" "Deicide Mask" "Royal Burgonet" "Sinner Tricorne" "Vaal Spirit Shield" "Conjurer Boots" "Conjurer Gloves" "Solaris Circlet"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 180 180 180 255       # BORDERCOLOR:	 Rares - Size - Small (+Great basetype)
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, bulky %HB3 %TB-RARE-T2-Arm
+	BaseType "Assassin's Garb" "Glorious Plate" "Astral Plate" "Spike-Point Arrow Quiver"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, armor, bulky %HB3 %TB-RARE-T2-Arm
+	BaseType "Assassin's Garb" "Glorious Plate" "Astral Plate" "Spike-Point Arrow Quiver"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 36
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#------------------------------------
+#   [0606] Breach Rings
+#------------------------------------
+
+Show #$great, tiny, breach
+	Class Rings
+	BaseType "Breach"
+	Rarity <= Rare
+	ItemLevel >= 75
+	SetFontSize 36
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 130 25 255 255        # BORDERCOLOR:	 Breach - accent
+	SetBackgroundColor 65 20 80          # BACKGROUND:	 Breach
+
+Show #$great, tiny, breach
+	Class Rings
+	BaseType "Breach"
+	Rarity <= Rare
+	SetFontSize 36
+	SetBorderColor 130 25 255 255        # BORDERCOLOR:	 Breach - accent
+	SetBackgroundColor 65 20 80          # BACKGROUND:	 Breach
+
+#------------------------------------
+#   [0607] Amulets, Jewels, Rings, Belts
+#------------------------------------
+#Amulets, rings and jewels don't care much about the droplevel
+#Also they're small, making them the ideal loottype. Always highlight them in a special (lime-green) hue
+
+Show #$trinkets, jewels, tiny %TC-Rare-Jewels
+	Class Jewel
+	Rarity Rare
+	SetFontSize 40
+	SetTextColor 255 255 0 255           # TEXTCOLOR:	 Jewel: Rare
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+	SetBackgroundColor 75 75 0 255       # BACKGROUND:	 Jewel: Rare
+
+Show #$great, tiny %TC-Rare-Trinkets
+	Class Rings Amulets Belts
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 40
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 25 235 25 255         # BORDERCOLOR:	 Rares - Size - Tiny, special base
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$great, tiny %TC-Rare-Trinkets
+	Class Rings Amulets Belts
+	Rarity Rare
+	SetFontSize 40
+	SetBorderColor 25 235 25 255         # BORDERCOLOR:	 Rares - Size - Tiny, special base
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+#------------------------------------
+#   [0608] 1H Daggers
+#------------------------------------
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Daggers
+	DropLevel >= 58
+	Class Daggers
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Daggers
+	DropLevel >= 58
+	Class Daggers
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+#------------------------------------
+#   [0609] 1H Claws
+#------------------------------------
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Claws
+	DropLevel >= 68
+	Class Claws
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Claws
+	DropLevel >= 68
+	Class Claws
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, small, autosmall %H1 %TD-Rare-Bad-Claws
+	DropLevel < 57
+	Class Claws
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, small, autosmall %H1 %TD-Rare-Bad-Claws
+	DropLevel < 57
+	Class Claws
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0610] 1H Wands
+#------------------------------------
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Wands
+	DropLevel >= 53
+	Class Wands
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-Wands
+	DropLevel >= 53
+	Class Wands
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+#------------------------------------
+#   [0611] 1H Swords and Foils
+#------------------------------------
+
+Show #$good, small %D2 %TD-Rare-Good-Swords
+	Width <= 1
+	Height <= 4
+	DropLevel >= 64
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %D2 %TD-Rare-Good-Swords
+	DropLevel >= 64
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small %D2 %TD-Rare-Good-Swords
+	Width <= 1
+	Height <= 4
+	DropLevel >= 64
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %D2 %TD-Rare-Good-Swords
+	DropLevel >= 64
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, small %H1 %TD-Rare-Bad-Swords
+	Width <= 1
+	Height <= 4
+	DropLevel <= 56
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Swords
+	DropLevel <= 56
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 28
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, small %H1 %TD-Rare-Bad-Swords
+	Width <= 1
+	Height <= 4
+	DropLevel <= 56
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Swords
+	DropLevel <= 56
+	Class "One Hand Swords"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 28
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0612] 1H Axes and Maces
+#------------------------------------
+Show #$good %HB2 %TB-Rare-Good-Maces-Axes
+	Class "One Hand Axes" "One Hand Maces"
+	BaseType "Siege Axe" "Vaal Hatchet" "Infernal Axe" "Runic Hatchet" "Behemoth Mace" "Nightmare Mace"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %HB2 %TB-Rare-Good-Maces-Axes
+	Class "One Hand Axes" "One Hand Maces"
+	BaseType "Siege Axe" "Vaal Hatchet" "Infernal Axe" "Runic Hatchet" "Behemoth Mace" "Nightmare Mace"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, small %H1 %TD-Rare-Bad-Maces-Axes
+	Width <= 1
+	Height <= 3
+	DropLevel <= 57
+	Class "One Hand Maces" "One Hand Axes"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Maces-Axes
+	DropLevel <= 57
+	Class "One Hand Maces" "One Hand Axes"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 28
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, small %H1 %TD-Rare-Bad-Maces-Axes
+	Width <= 1
+	Height <= 3
+	DropLevel <= 57
+	Class "One Hand Maces" "One Hand Axes"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Maces-Axes
+	DropLevel <= 57
+	Class "One Hand Maces" "One Hand Axes"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 28
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0613] 1H Sceptres
+#------------------------------------
+
+Show #$good %HB2 %TD-Rare-Good-Sceptres
+	DropLevel >= 64
+	Class "Sceptres"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %HB2 %TD-Rare-Good-Sceptres
+	DropLevel >= 64
+	Class "Sceptres"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+#------------------------------------
+#   [0614] 2H Staves
+#------------------------------------
+
+Show #$good, bulky %D1 %TD-Rare-Good-Staves
+	DropLevel >= 68
+	Class "Staves"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, bulky %D1 %TD-Rare-Good-Staves
+	DropLevel >= 68
+	Class "Staves"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, bulky %D1 %TB-Rare-Good-Staves
+	Class "Staves"
+	BaseType "Lathi"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, bulky %D1 %TB-Rare-Good-Staves
+	Class "Staves"
+	BaseType "Lathi"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-Staves
+	DropLevel <= 58
+	Class "Staves"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 24
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-Staves
+	DropLevel <= 58
+	Class "Staves"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 24
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0615] 2H Swords, Axes, Maces
+#------------------------------------
+
+Show #$good, bulky %HB1 %TD-Rare-Good-2H-Axes-Maces-Swords
+	DropLevel >= 65
+	Class "Two Hand"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, bulky %HB1 %TD-Rare-Good-2H-Axes-Maces-Swords
+	DropLevel >= 65
+	Class "Two Hand"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-2H-Axes-Maces-Swords
+	DropLevel <= 59
+	Class "Two Hand"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 24
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-2H-Axes-Maces-Swords
+	DropLevel <= 59
+	Class "Two Hand"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 24
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0616] 2H Bows
+#------------------------------------
+
+Show #$good, bulky %D2 %TD-Rare-Good-Bows
+	DropLevel >= 62
+	Class "Bows"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, bulky %D2 %TD-Rare-Good-Bows
+	DropLevel >= 62
+	Class "Bows"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-Bows
+	DropLevel <= 50
+	Class "Bows"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 24
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, bulky %H1 %TD-Rare-Bad-Bows
+	DropLevel <= 50
+	Class "Bows"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 24
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0617] AR: Gloves, Boots, Helmets
+#------------------------------------
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-SmallArmor
+	DropLevel >= 43
+	Class "Gloves" "Boots" "Helmets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %HB2 %TD-Rare-Good-SmallArmor
+	DropLevel >= 43
+	Class "Gloves" "Boots" "Helmets"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, small, autosmall %H1 %TD-Rare-Bad-SmallArmor
+	DropLevel <= 15
+	Class "Gloves" "Boots" "Helmets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, small, autosmall %H1 %TD-Rare-Bad-SmallArmor
+	DropLevel <= 15
+	Class "Gloves" "Boots" "Helmets"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0618] AR: Body Armors
+#------------------------------------
+
+Show #ok, hybrid %H1 %TB-Rare-Hybrid-Exceptions
+	Class "Body Armour"
+	BaseType "Dragonscale Doublet" "Blood Raiment" "Full Dragonscale" "Elegant Ringmail" "Varnished Coat" "Conquest Chainmail" "Desert Brigandine"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+Show #ok, hybrid %H1 %TB-Rare-Hybrid-Exceptions
+	Class "Body Armour"
+	BaseType "Dragonscale Doublet" "Blood Raiment" "Full Dragonscale" "Elegant Ringmail" "Varnished Coat" "Conquest Chainmail" "Desert Brigandine"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+Show #$good %HB2 %TD-Rare-Good-Armor
+	DropLevel >= 60
+	Class "Body Armour"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %HB2 %TD-Rare-Good-Armor
+	DropLevel >= 60
+	Class "Body Armour"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad %H1 %TD-Rare-Bad-Armor
+	DropLevel <= 47
+	Class "Body Armour"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 26
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Armor
+	DropLevel <= 47
+	Class "Body Armour"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 26
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0619] OH: Shields
+#------------------------------------
+
+Show #$good, small %HB2 %TD-Rare-Good-Shields
+	Width <= 2
+	Height <= 2
+	DropLevel >= 65
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %D2 %TD-Rare-Good-Shields
+	DropLevel >= 65
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small %HB2 %TD-Rare-Good-Shields
+	Width <= 2
+	Height <= 2
+	DropLevel >= 65
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %D2 %TD-Rare-Good-Shields
+	DropLevel >= 65
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %D2 %TD-Rare-Good-EsShields
+	DropLevel >= 55
+	Class "Shields"
+	BaseType "Spirit Shield"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %D2 %TD-Rare-Good-EsShields
+	DropLevel >= 55
+	Class "Shields"
+	BaseType "Spirit Shield"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$ok, small, autosmall %D2
+	Class "Shields"
+	BaseType "Spirit Shield"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+
+Show #$ok, small, autosmall %D2
+	Class "Shields"
+	BaseType "Spirit Shield"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+
+Show #$good %D2 %TB-Rare-Good-ArEsShields
+	Class "Shields"
+	BaseType "Branded Kite Shield" "Champion Kite Shield"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %D2 %TB-Rare-Good-ArEsShields
+	Class "Shields"
+	BaseType "Branded Kite Shield" "Champion Kite Shield"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %D2 %TD-Rare-Good-Ev-EvEs-Shields
+	DropLevel >= 66
+	Class "Shields"
+	BaseType "Buckler" "Spiked Shield"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 35
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good, small, autosmall %D2 %TD-Rare-Good-Ev-EvEs-Shields
+	DropLevel >= 66
+	Class "Shields"
+	BaseType "Buckler" "Spiked Shield"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$bad, small %H1 %TD-Rare-Bad-Shields
+	Width <= 2
+	Height <= 2
+	DropLevel <= 52
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Shields
+	DropLevel <= 52
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad, small %H1 %TD-Rare-Bad-Shields
+	Width <= 2
+	Height <= 2
+	DropLevel <= 52
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 150       # BORDERCOLOR:	 Rares - Size - Small (+Bad basetype)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+Show #$bad %H1 %TD-Rare-Bad-Shields
+	DropLevel <= 52
+	Class "Shields"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 26
+	SetBorderColor 0 0 0 220             # BORDERCOLOR:	 Rares - Size - OK (+Bad base)
+	SetBackgroundColor 120 20 20 150     # BACKGROUND:	 Rares - Basetypes - Bad.
+
+#------------------------------------
+#   [0620] OH: Quivers
+#------------------------------------
+
+Show #$good %HB2 %TB-Rare-Good-Quivers
+	Class "Quivers"
+	BaseType "Spike-Point Arrow Quiver" "Broadhead Arrow Quiver" "Two-Point Arrow Quiver"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$good %HB2 %TB-Rare-Good-Quivers
+	Class "Quivers"
+	BaseType "Spike-Point Arrow Quiver" "Broadhead Arrow Quiver" "Two-Point Arrow Quiver"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+#------------------------------------
+#   [0621] Rare endgame items - remaining rules
+#------------------------------------
+#Catch rares that didn't match any of the entries above
+
+Show #$small, ok %D2 %TC-Rareable
+	Width <= 2
+	Height <= 2
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$small, ok %D2 %TC-Rareable
+	Width <= 1
+	Height <= 3
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 32
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$ok, bulky %H1 %TC-Rareable
+	Width >= 2
+	Height >= 4
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 26
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$ok, bulky %H1 %TC-Rareable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$small, ok %D2 %TC-Rareable
+	Width <= 2
+	Height <= 2
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$small, ok %D2 %TC-Rareable
+	Width <= 1
+	Height <= 3
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 32
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$ok, bulky %H1 %TC-Rareable
+	Width >= 2
+	Height >= 4
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 26
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$ok %D2 %TC-Rareable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 75
+	SetFontSize 30
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$ok %D2 %TC-Rareable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	Rarity Rare
+	ItemLevel >= 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+#===============================================================================================================
+# [[0700]] HIDE LAYER 2 - RARE ITEMS (65+ ONLY FOR NON-REGULAR VERSIONS)
+#===============================================================================================================
+# Hide remaining rares
+
+Hide # Hide remaining rare endgame items (note: on the regular version this line never happens) %TC-Rareable-Junkable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields"
+	Rarity = Rare
+	ItemLevel >= 75
+	SetFontSize 26
+	SetTextColor 255 190 0               # TEXTCOLOR:	 Rares - Level - 75+
+	SetBorderColor 0 0 0 100             # BORDERCOLOR:	 Cosmetic: Junk
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Hide # Hide remaining rare endgame items (note: on the regular version this line never happens) %TC-Rareable-Junkable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Daggers" "Shields"
+	Rarity = Rare
+	ItemLevel >= 65
+	SetFontSize 26
+	SetBorderColor 0 0 0 100             # BORDERCOLOR:	 Cosmetic: Junk
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#===============================================================================================================
+# [[0800]] OVERRIDE AREA 3 - Override Map, Gem and Flask drops here
+#===============================================================================================================
+
+#===============================================================================================================
+# [[0900]] Gems
+#===============================================================================================================
+
+#------------------------------------
+#   [0901] Value gems
+#------------------------------------
+
+Show # %TB-Qual-Top-Gem
+	Quality >= 15
+	Class Gems
+	BaseType "Empower" "Enlighten"
+	SetFontSize 45
+	SetTextColor 30 200 200 255          # TEXTCOLOR:	 T1 Gem
+	SetBorderColor 30 150 180 255        # BORDERCOLOR:	 T1 Gems
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show
+	Quality >= 20
+	Class Gems
+	SetFontSize 45
+	SetTextColor 30 200 200 255          # TEXTCOLOR:	 T1 Gem
+	SetBorderColor 30 150 180 255        # BORDERCOLOR:	 T1 Gems
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 3 300                 # DROPSOUND:	 Random uniques, 20qual gems
+
+Show # Drop only good gems %TB-Top-Gem
+	Class Gems
+	BaseType "Portal" "Empower" "Enlighten" "Vaal Haste" "Vaal Discipline" "Item Quantity" "Vaal Breach"
+	SetFontSize 42
+	SetTextColor 30 200 200 255          # TEXTCOLOR:	 T1 Gem
+	SetBorderColor 30 150 180 255        # BORDERCOLOR:	 T1 Gems
+	PlayAlertSound 3 300                 # DROPSOUND:	 Random uniques, 20qual gems
+
+
+Show
+	Quality >= 14
+	Class Gems
+	SetFontSize 40
+	SetTextColor 30 200 200 255          # TEXTCOLOR:	 T1 Gem
+	SetBorderColor 30 150 180 255        # BORDERCOLOR:	 T1 Gems
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [0902] Other gems
+#------------------------------------
+
+
+Show
+	Quality >= 1
+	Class Gems
+	SetFontSize 38
+	SetBorderColor 30 150 180 150        # BORDERCOLOR:	 T2 Gems
+
+Show # Drop only meh gems %TB-DropOnly-Gem
+	Class Gems
+	BaseType "Detonate Mines" "Added Chaos Damage" "Vaal" "Enhance"
+	SetFontSize 38
+	SetBorderColor 30 150 180 150        # BORDERCOLOR:	 T2 Gems
+
+Show # %H2
+	Class Gems
+	SetFontSize 34
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+#===============================================================================================================
+# [[1000]] FLASKS (Endgame rules)
+#===============================================================================================================
+
+Show #$flask, recipe, glass, top %H4
+	Quality = 20
+	BaseType "Flask"
+	Rarity Normal
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, recipe, glass, top %H4
+	Quality = 20
+	BaseType "Flask"
+	Rarity Magic
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, recipe, glass %H4
+	Quality >= 15
+	BaseType "Flask"
+	Rarity <= Magic
+	ItemLevel < 60
+	SetFontSize 40
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, utility, lvl, top %TB-T1-Leveling-Flask
+	Quality >= 1
+	BaseType "Quicksilver Flask" "Silver Flask" "Bismuth Flask" "Basalt Flask" "Granite Flask" "Diamond Flask"
+	Rarity <= Magic
+	ItemLevel >= 5
+	ItemLevel < 60
+	SetFontSize 42
+	SetBorderColor 250 250 250           # BORDERCOLOR:	 Recipes: top component / very strong leveling highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, utility, lvl %TB-T1-Leveling-Flask
+	BaseType "Quicksilver Flask" "Silver Flask" "Bismuth Flask" "Basalt Flask" "Granite Flask" "Diamond Flask"
+	Rarity <= Magic
+	ItemLevel < 60
+	SetFontSize 40
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, recipe, glass %D2
+	Quality >= 15
+	BaseType "Flask"
+	Rarity <= Magic
+	SetFontSize 38
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, recipe, glass
+	Quality > 1
+	BaseType "Flask"
+	Rarity <= Magic
+	ItemLevel < 60
+	SetFontSize 38
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, recipe, glass %D2
+	Quality >= 1
+	BaseType "Flask"
+	Rarity <= Magic
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, utility %D2
+	Class "Utility Flasks"
+	Rarity <= Magic
+	ItemLevel > 66
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$flask, utility
+	Class "Utility Flasks"
+	Rarity <= Magic
+	ItemLevel < 67
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+#===============================================================================================================
+# [[1100]] HIDE LAYER 3: Random Endgame Flasks
+#===============================================================================================================
+
+Hide #$flask
+	BaseType Flask
+	Rarity <= Magic
+	ItemLevel >= 69
+	SetFontSize 20
+
+#===============================================================================================================
+# [[1200]] Maps, fragments and labyrinth items
+#===============================================================================================================
+
+#------------------------------------
+#   [1201] Unique Maps
+#------------------------------------
+
+Show # Maps:Unique - T1 - only museum is needed, but legacy might have some surprises.
+	Class Maps
+	BaseType "Chateau Map" "Museum Map" "Courtyard Map"
+	Rarity Unique
+	SetFontSize 45
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # Maps:Unique
+	Class Maps
+	Rarity Unique
+	SetFontSize 42
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+#------------------------------------
+#   [1202] Labyrinth items, Offerings
+#------------------------------------
+
+Show # %TB-OfferingToTheGoddess
+	BaseType "Offering to the Goddess"
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 180 0 0 255       # BACKGROUND:	 Fragments - valuable
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show
+	Class "Labyrinth"
+	SetFontSize 42
+	SetTextColor 74 230 58               # TEXTCOLOR:	 Labyrinth, Quest, Shaper Orbs
+	SetBorderColor 74 230 58             # BORDERCOLOR:	 Labyrinth, Quest, Shaper Orbs
+
+#------------------------------------
+#   [1203] Top tier maps (T15-16)
+#------------------------------------
+
+Show # Maps:T16 %TB-Maps-T16
+	Class Maps
+	BaseType "Forge of the Phoenix Map" "Maze of the Minotaur Map" "Lair of the Hydra Map" "Pit of the Chimera Map" "Vaal Temple Map"
+	SetFontSize 45
+	SetTextColor 100 0 122 255           # TEXTCOLOR:	 Cosmetic: T16 guardian maps
+	SetBorderColor 100 0 255 255         # BORDERCOLOR:	 Cosmetic: T16 guardian maps
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # Maps:T15
+	DropLevel >= 82
+	Class Maps
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+#------------------------------------
+#   [1204] High tier maps(T11-14)
+#------------------------------------
+
+Show # Maps:T14
+	DropLevel >= 81
+	Class Maps
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 200 200 200 255   # BACKGROUND:	 T11-T14 maps
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T13
+	DropLevel >= 80
+	Class Maps
+	SetFontSize 44
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 200 200 200 255   # BACKGROUND:	 T11-T14 maps
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T12
+	DropLevel >= 79
+	Class Maps
+	SetFontSize 43
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 200 200 200 255   # BACKGROUND:	 T11-T14 maps
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T11
+	DropLevel >= 78
+	Class Maps
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 200 200 200 255   # BACKGROUND:	 T11-T14 maps
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+#------------------------------------
+#   [1205] Mid tier maps (T6-10)
+#------------------------------------
+
+Show # Maps:T10
+	DropLevel >= 77
+	Class Maps
+	SetFontSize 40
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+#------------------------------------
+#  T9 - Maps
+#------------------------------------
+
+Show # Maps:T9 - OnLevel
+	DropLevel >= 76
+	Class Maps
+	ItemLevel < 83
+	SetFontSize 40
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T9
+	DropLevel >= 76
+	Class Maps
+	BaseType "Shaped"
+	SetFontSize 38
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T9 %H4
+	DropLevel >= 76
+	Class Maps
+	SetFontSize 36
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T8 - Maps
+#------------------------------------
+
+Show # Maps:T8 - OnLevel
+	DropLevel >= 75
+	Class Maps
+	ItemLevel < 82
+	SetFontSize 40
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T8
+	DropLevel >= 75
+	Class Maps
+	BaseType "Shaped"
+	SetFontSize 38
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T8 %H4
+	DropLevel >= 75
+	Class Maps
+	SetFontSize 36
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T7 - Maps
+#------------------------------------
+
+Show # Maps:T7 - OnLevel
+	DropLevel >= 74
+	Class Maps
+	ItemLevel < 81
+	SetFontSize 40
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T7
+	DropLevel >= 74
+	Class Maps
+	BaseType "Shaped"
+	SetFontSize 38
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T7 %H4
+	DropLevel >= 74
+	Class Maps
+	SetFontSize 36
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T6 - Maps
+#------------------------------------
+
+Show # Maps:T6 - OnLevel
+	DropLevel >= 73
+	Class Maps
+	ItemLevel < 80
+	SetFontSize 39
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T6
+	DropLevel >= 73
+	Class Maps
+	BaseType "Shaped"
+	SetFontSize 38
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T6 %H4
+	DropLevel >= 73
+	Class Maps
+	SetFontSize 36
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#   [1206] Low tier maps (T1-T5)
+#------------------------------------
+
+Show # Maps:T5 - OnLevel
+	DropLevel >= 72
+	Class Maps
+	ItemLevel < 79
+	SetFontSize 38
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T5 %H3
+	DropLevel >= 72
+	Class Maps
+	SetFontSize 34
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T4 - Maps
+#------------------------------------
+
+Show # Maps:T4 - OnLevel
+	DropLevel >= 71
+	Class Maps
+	ItemLevel < 78
+	SetFontSize 37
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T4 %H3
+	DropLevel >= 71
+	Class Maps
+	SetFontSize 34
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T3 - Maps
+#------------------------------------
+
+Show # Maps:T3 - OnLevel
+	DropLevel >= 70
+	Class Maps
+	ItemLevel < 77
+	SetFontSize 37
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T3 %H3
+	DropLevel >= 70
+	Class Maps
+	SetFontSize 34
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T2 - Maps
+#------------------------------------
+
+Show # Maps:T2 - OnLevel
+	DropLevel = 69
+	Class Maps
+	ItemLevel < 76
+	SetFontSize 36
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T2 %H3
+	DropLevel = 69
+	Class Maps
+	SetFontSize 34
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#  T1 - Maps
+#------------------------------------
+
+Show # Maps:T1 - OnLevel
+	DropLevel < 69
+	Class Maps
+	ItemLevel < 75
+	SetFontSize 36
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+Show # Maps:T1 %H3
+	DropLevel < 69
+	Class Maps
+	SetFontSize 34
+	SetTextColor 150 150 150             # TEXTCOLOR:	 Outleveled Maps
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show # Safetyline
+	Class Maps
+	SetFontSize 42
+	PlayAlertSound 4 300                 # DROPSOUND:	 T1 maps
+
+#------------------------------------
+#   [1207] Map fragments
+#------------------------------------
+
+Show # "Ancient Reliquary Key" - the following section handles it (it's classified as a ""Misc Map Items" by GGG). No it's not hidden, stop asking me, crazy people.
+	Class "Misc Map Items"
+	SetFontSize 45
+	SetTextColor 230 120 0 255           # TEXTCOLOR:	 Relic Keys, Breachstones
+	SetBorderColor 230 120 0 255         # BORDERCOLOR:	 Relic Keys, Breachstones
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # %TB-Fragments-T1
+	Class "Map Fragments"
+	BaseType "Mortal Hope" "Mortal Ignorance"
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # %TB-Fragments-T1-Expected
+	Class "Map Fragments"
+	BaseType "Fragment of the Phoenix" "Fragment of the Minotaur" "Fragment of the Chimera" "Fragment of the Hydra" "Breachstone"
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # %TB-Fragments-T2
+	Class "Map Fragments"
+	BaseType "Mortal" "Eber's Key" "Yriel's Key" "Inya's Key" "Volkuur's Key" "Sacrifice at Midnight"
+	SetFontSize 44
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 180 0 0 255       # BACKGROUND:	 Fragments - valuable
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show
+	Class "Map Fragments"
+	SetFontSize 38
+	SetTextColor 180 0 0 255             # TEXTCOLOR:	 Map fragments
+	SetBorderColor 180 0 0 255           # BORDERCOLOR:	 Fragments: Random
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#===============================================================================================================
+# [[1300]] Currency - PART 2 - Rare currency
+#===============================================================================================================
+
+#------------------------------------
+#   [1301] Regular Rare Currency
+#------------------------------------
+
+Show # %TB-Currency-T2
+	Class Currency
+	BaseType "Regal Orb" "Orb of Regret" "Chaos Orb" "Gemcutter's Prism" "Vaal Orb" "Master Cartographer" "Journeyman Cartographer" "Stacked Deck"
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 249 150 25 255    # BACKGROUND:	 T2 Currency
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # %TB-Currency-T3
+	Class Currency
+	BaseType "Blessed Orb" "Orb of Fusing" "Orb of Scouring" "Orb of Alchemy" "Cartographer's Chisel" "Glassblower's Bauble" "Cartographer's Sextant" "Silver Coin"
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 213 159 0 255     # BACKGROUND:	 T3 Currency
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [1302] Top Currency
+#------------------------------------
+
+Show #$top %TB-Currency-T1
+	Class Currency
+	BaseType "Mirror of Kalandra" "Eternal Orb" "Divine Orb" "Exalted Orb" "Albino Rhoa Feather"
+	SetFontSize 45
+	SetTextColor 255 0 0 255             # TEXTCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBorderColor 255 0 0 255           # BORDERCOLOR:	 T1 items: currency, 6L, fishing rod
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+#------------------------------------
+#   [1303] Essence Tier List
+#------------------------------------
+
+Show # %TB-Essence-T1
+	Class Currency
+	BaseType "Shrieking Essence of" "Essence of Hysteria" "Essence of Insanity" "Essence of Horror" "Essence of Delirium" "Deafening Essence of" "Remnant of Corruption"
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 249 150 50 255    # BACKGROUND:	 T2 Currency
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show
+	Class Currency
+	BaseType "Screaming Essence of"
+	SetFontSize 40
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 15 180 200 255    # BACKGROUND:	 Essence LVL5
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show
+	Class Currency
+	BaseType "Wailing Essence of"
+	SetFontSize 38
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 159 200 255    # BACKGROUND:	 Essence LVL4
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+
+Show
+	Class Currency
+	BaseType "Weeping Essence of"
+	SetFontSize 36
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 159 200 225    # BACKGROUND:	 Essence LVL3
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show
+	Class Currency
+	BaseType "Muttering Essence of"
+	SetFontSize 36
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 159 200 200    # BACKGROUND:	 Essence LVL2
+
+
+Show
+	Class Currency
+	BaseType "Whispering Essence of"
+	SetFontSize 34
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 30 159 200 175    # BACKGROUND:	 Essence LVL1
+
+#------------------------------------
+#   [1304] Special items
+#------------------------------------
+
+Show # Blessing
+	Class Currency
+	BaseType "Blessing"
+	SetFontSize 45
+	SetTextColor 130 25 255 255          # TEXTCOLOR:	 Breach Currency
+	SetBorderColor 130 25 255 255        # BORDERCOLOR:	 Breach - accent
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # Splinter
+	Class Currency
+	BaseType "Splinter"
+	SetFontSize 40
+	SetTextColor 255 235 235 255         # TEXTCOLOR:	 Breach Currency
+	SetBorderColor 130 25 255 255        # BORDERCOLOR:	 Breach - accent
+	SetBackgroundColor 65 20 80          # BACKGROUND:	 Breach
+	PlayAlertSound 2 100                 # DROPSOUND:	 Breach Splinters
+
+
+Show
+	Class Currency
+	BaseType "Perandus Coin"
+	SetFontSize 38
+	SetTextColor 255 178 135 255         # TEXTCOLOR:	 Perandus Coins
+	SetBorderColor 255 178 135 135       # BORDERCOLOR:	 Perandus Coin
+
+Show # %TB-Currency-NonDrop1
+	Class Currency
+	BaseType "Unshaping Orb" "Cartographer's Seal"
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 249 150 50 255    # BACKGROUND:	 T2 Currency
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # %TB-Currency-NonDrop2
+	Class Currency
+	BaseType "Prophecy"
+	SetFontSize 40
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 159 15 213        # BACKGROUND:	 Itemized Prophecy
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#===============================================================================================================
+# [[1400]] Currency - PART 3 - Divination cards (yes the strange sorting is intended)
+#===============================================================================================================
+
+#------------------------------------
+#   [1401] Exceptions to prevent ident. mistakes
+#------------------------------------
+
+Show # %TB-Divination-Exception
+	Class "Divination"
+	BaseType "The Wolf's Shadow"
+	SetFontSize 38
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 100 150 255         # BORDERCOLOR:	 Cosmetic: T4 Divination
+	SetBackgroundColor 145 215 230 225   # BACKGROUND:	 T4 Divination
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [1402] T1 - Top tier cards
+#------------------------------------
+
+Show # %TB-Divination-T1
+	Class "Divination"
+	BaseType "House of Mirrors" "The Doctor" "The Fiend" "Hunter's Reward" "The Dragon's Heart" "Mawr Blaidd" "The Last One Standing" "The Offering" "The Ethereal" "The Queen" "Abandoned Wealth" "The Brittle Emperor" "The Immortal" "The Artist" "Wealth and Power" "Pride Before the Fall" "The Enlightened" "The King's Heart" "Bowyer's Dream" "The Hunger" "The Celestial Justicar" "Spark and the Flame" "Polymath"
+	SetFontSize 45
+	SetTextColor 0 0 255 255             # TEXTCOLOR:	 Cosmetic: T1 Divination card
+	SetBorderColor 0 0 255 255           # BORDERCOLOR:	 Cosmetic: T1 and T2 Divination
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+#------------------------------------
+#   [1403] T2 - Great cards
+#------------------------------------
+
+Show # %TB-Divination-T2
+	Class "Divination"
+	BaseType "Chaotic Disposition" "The Void" "The Cartographer" "The Dapper Prodigy" "The Vast" "The Dark Mage" "Last Hope" "The Valkyrie" "The Sephirot" "The Hoarder" "The Chains that Bind" "The Warlord" "The Aesthete" "Saint's Treasure" "The Thaumaturgist" "Heterochromia" "The Porcupine" "The Stormcaller" "The Soul" "Emperor of Purity"
+	SetFontSize 44
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 255 255 0 255         # BORDERCOLOR:	 Crafting: T1
+	SetBackgroundColor 100 250 250 245   # BACKGROUND:	 T2 Divination
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [1404] T3 - Decent cards
+#------------------------------------
+
+Show # %TB-Divination-T3
+	Class "Divination"
+	BaseType "The Road to Power" "The Arena Champion" "The Gladiator" "Glimmer of Hope" "The Tyrant" "The Union" "The Risk" "The Trial" "Scholar of the Seas" "Lucky Deck" "Humility" "The Penitent" "The Penitent" "The Surveyor" "Lysah's Respite" "The Inventor" "The Jester" "Vinia's Token" "Rats" "The Wrath" "Hope" "Treasure Hunter" "The Explorer" "The Body" "Jack in the Box" "The Traitor" "Valley of Steel Boxes" "Wolven King's Bite" "Wretched" "The Opulent" "Might is Right" "The Fletcher" "The Forsaken" "The Formless Sea" "The Demoness" "Time-Lost Relic" "The Wolf" "Earth Drinker" "Standoff" "Merciless Armament"
+	SetFontSize 40
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 255 255           # BORDERCOLOR:	 Cosmetic: T1 and T2 Divination
+	SetBackgroundColor 50 220 240 235    # BACKGROUND:	 T3 Divination
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#------------------------------------
+#   [1405] T5 - Format trash tier cards... before
+#------------------------------------
+
+Show # %H3 %TB-Divination-T5
+	Class "Divination"
+	BaseType "Carrion Crow" "Other Cheek" "Hermit" "King's Blade" "Thunderous Skies" "Metalsmith's Gift"
+	SetFontSize 32
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 175 215 230 180   # BACKGROUND:	 T5 Divination
+
+#------------------------------------
+#   [1406] T4 - ...showing the remaining cards
+#------------------------------------
+
+
+Show
+	Class "Divination"
+	SetFontSize 38
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 100 150 255         # BORDERCOLOR:	 Cosmetic: T4 Divination
+	SetBackgroundColor 145 215 230 225   # BACKGROUND:	 T4 Divination
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#===============================================================================================================
+# [[1500]] Currency - PART 4 - remaining items
+#===============================================================================================================
+
+Show # %H2 %TB-Currency-T8
+	Class Currency
+	BaseType "Scroll Fragment" "Transmutation Shard"
+	SetFontSize 28
+	SetTextColor 170 158 130 165         # TEXTCOLOR:	 Low currency T4
+
+Show # %H3
+	Class Currency
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+
+#===============================================================================================================
+# [[1600]] Leaguestones - Tierlists
+#===============================================================================================================
+
+Show # %TB-Leaguestone-Value
+	Class Leaguestone
+	BaseType "Perandus" "Breach" "Nemesis" "Bloodline"
+	Rarity = Magic
+	ItemLevel >= 67
+	SetFontSize 45
+	SetTextColor 50 0 100 255            # TEXTCOLOR:	 LeagueStone Magic
+	SetBorderColor 50 0 100 255          # BORDERCOLOR:	 LeagueStone Magic
+	SetBackgroundColor 90 240 140 255    # BACKGROUND:	 LeagueStone T1
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+
+Show
+	Class Leaguestone
+	Rarity >= Magic
+	SetFontSize 42
+	SetTextColor 50 0 100 255            # TEXTCOLOR:	 LeagueStone Magic
+	SetBorderColor 50 0 100 255          # BORDERCOLOR:	 LeagueStone Magic
+	SetBackgroundColor 100 220 145 255   # BACKGROUND:	 LeagueStone T2
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+Show # %TB-Leaguestone-Value
+	Class Leaguestone
+	BaseType "Perandus" "Breach" "Nemesis" "Bloodline"
+	Rarity = Normal
+	ItemLevel >= 67
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 100 220 145 255   # BACKGROUND:	 LeagueStone T2
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+
+Show
+	Class Leaguestone
+	Rarity = Normal
+	SetFontSize 40
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 70 160 100 230    # BACKGROUND:	 LeagueStone T3
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
+
+#===============================================================================================================
+# [[1700]] Uniques!
+#===============================================================================================================
+
+#------------------------------------
+#   [1701] Exceptions
+#------------------------------------
+
 
 Show
 	SocketGroup WWWWWW
 	BaseType "Simple Robe"
 	Rarity Unique
-	PlayAlertSound 6 300
-	SetBackgroundColor 175 96 37 255
-	SetBorderColor 255 150 000 255
-	SetTextColor 0 0 0 255
-	SetFontSize 43
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show
+Show # 6-Links
 	LinkedSockets 6
-	SetTextColor 255 0 0
-	SetBorderColor 255 0 0
-	SetBackgroundColor 255 255 255 255
+	Rarity Unique
 	SetFontSize 45
-	PlayAlertSound 6 300
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show
-	BaseType "Mirror of Kalandra"
-	SetTextColor 255 0 0 255
-	SetBorderColor 255 0 0 255
-	SetBackgroundColor 255 255 255 255
+#------------------------------------
+#   [1702] Tier 1 uniques
+#------------------------------------
+
+Show # %TB-Uniques-T1-Flasks
+	BaseType "Stibnite Flask" "Ruby Flask" "Topaz Flask" "Sapphire Flask" "Silver Flask"
+	Rarity Unique
 	SetFontSize 45
-	PlayAlertSound 6 300
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-#------------------------------------------------------------------------
-# Section: 0200 # UNIQUES AND MAPS
-#------------------------------------------------------------------------
-
-#----------------------------------------------------
-# 0201 # UNIQUE TIER LIST
-#----------------------------------------------------
-
-Show # T1 - These uniques are have a consistent price of ~0.5++ ex
-	BaseType "Varnished Coat" "Gold Ring" "Ursine Pelt" "Champion Kite Shield" "Slaughter Knife" "Sapphire Flask" "Desert Brigandine" "Occultist" "Glorious" "Titanium"  "Judgement Staff" "Siege Axe" "Spine Bow" "Prophecy Wand" "Sacrificial Garb" "Sorcerer Boots" "Topaz Flask" "Deicide Mask" "Imperial Skean" "Rawhide Boots" "Fiend Dagger"
+Show # %TB-Uniques-T1-Wep
+	BaseType "Void Axe" "Prophecy Wand" "Jewelled Foil" "Royal Axe" "Cutlass"
 	Rarity Unique
-	PlayAlertSound 6 300
-	SetBackgroundColor 255 255 255 255
-	SetBorderColor 175 96 37 255
-	SetTextColor 175 96 37 255
 	SetFontSize 45
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show # T2 - These uniques usually are worth ~0.5-1 ex at the start of the league and drop to ~5c++ (sometimes ranging to an ex and up) over 1-2 month.
-	BaseType "Golden Plate" "Nubuck Boots" "Serpentine Staff" "Vile Staff" "Terror Maul" "Full Wyrmscale" "Gavel" "Archon Kite Shield" "Opal Wand" "Reinforced Greaves" "Vaal Gauntlets" "Imperial Bow" "Conjurer Boots" "Steelscale Gauntlets" "Amethyst Ring" "Crusader Plate" "Ezomyte Burgonet" "Nightmare Bascinet" "Sharkskin Boots" "Two-Stone" "Granite Flask" "Imperial Staff" "Penetrating" "Deerskin Gloves" "Sinner Tricorne" "Karui Sceptre"  "Large Hybrid Flask" "Paua Ring" "Hubris"
+Show # %TB-Uniques-T1-Arm
+	BaseType "Sorcerer Boots" "Occultist's Vestment" "Crusader Boots" "Rawhide Boots" "Ezomyte Tower Shield" "Deicide Mask" "Glorious Plate" "Ezomyte Burgonet" "Assassin's Garb"
 	Rarity Unique
-	PlayAlertSound 6 300
-	SetBackgroundColor 200 96 37 255
-	SetBorderColor 0 0 0 255
-	SetTextColor 0 0 0 255
-	SetFontSize 43
+	SetFontSize 45
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show # T3 - Random uniques. In some cases, such as jewels some very valuable uniques may be still in here, but it's impossible to identify them.
+Show # %TB-Uniques-T1-Misc
+	BaseType "Greatwolf Talisman"
 	Rarity Unique
-	PlayAlertSound 6 300
-	SetBorderColor 175 96 37 254
-	SetTextColor 175 96 37 254
-	SetBackgroundColor 0 0 0 254
-	SetFontSize 39
+	SetFontSize 45
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T1 Global High Value Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-#----------------------------------------------------
-# 0202 # MAP TIER LIST
-#----------------------------------------------------
+#------------------------------------
+#   [1703] Tier 2 uniques
+#------------------------------------
 
-Show # Maps:Unique
-	Class Map
+Show # 5-Links
+	LinkedSockets = 5
 	Rarity Unique
-	SetFontSize 40
-	PlayAlertSound 6 300
+	SetFontSize 45
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show # Maps:T1
-	Class Map
-	BaseType "Crypt" "Desert" "Dunes" "Dungeon" "Grotto" "Pit Map" "Tropical Island"
-	SetFontSize 34
-	PlayAlertSound 4 300
-
-Show # Maps:T2
-	Class Map
-	BaseType "Arcade" "Cemetery" "Channel" "Mountain Ledge" "Sewer" "Thicket" "Wharf"
-	SetFontSize 35
-	PlayAlertSound 4 300
-
-Show # Maps:T3
-	Class Map
-	BaseType "Ghetto" "Mud Geyser" "Museum" "Quarry" "Reef" "Spider Lair" "Vaal Pyramid"
-	SetFontSize 36
-	PlayAlertSound 4 300
-
-Show # Maps:T4
-	Class Map
-	BaseType "Arena" "Overgrown Shrine" "Promenade" "Shore" "Spider Forest" "Tunnel" "Phantasmagoria"
-	SetFontSize 37
-	PlayAlertSound 4 300
-
-Show # Maps:T5
-	Class Map
-	BaseType "Bog Map" "Coves" "Graveyard" "Pier" "Underground Sea" "Villa Map"
-	SetFontSize 38
-	PlayAlertSound 4 300
-
-Show # Maps:T6
-	Class Map
-	BaseType "Arachnid" "Catacomb" "Colonnade" "Dry Woods" "Strand" "Temple"
-	SetFontSize 39
-	PlayAlertSound 4 300
-
-Show # Maps:T7
-	Class Map
-	BaseType "Jungle Valley" "Terrace" "Torture Chamber" "Waste Pool" "Abandoned Cavern"
-	SetFontSize 40
-	PlayAlertSound 4 300
-#	SetBackgroundColor 100 100 0 255
-#	SetBorderColor 200 200 0 255
-
-Show # Maps:T8
-	Class Map
-	BaseType "Canyon" "Cells" "Dark Forest" "Dry Peninsula" "Orchard"
-	SetFontSize 41
-	PlayAlertSound 4 300
-#	SetBackgroundColor 100 100 0 255
-#	SetBorderColor 200 200 0 255
-
-Show # Maps:T9
-	Class Map
-	BaseType "Arid Lake" "Gorge" "Residence" "Underground River" "Malformation"
-	SetFontSize 41
-	PlayAlertSound 4 300
-#	SetBackgroundColor 100 100 0 255
-#	SetBorderColor 200 200 0 255
-
-Show # Maps:T10
-	Class Map
-	BaseType "Bazaar" "Necropolis" "Plateau" "Volcano" "Chateau"
+Show # %TB-Uniques-T2-Flasks
+	BaseType "Granite Flask" "Bismuth Flask"
+	Rarity Unique
 	SetFontSize 42
-	PlayAlertSound 4 300
-#	SetBackgroundColor 100 100 0 255
-#	SetBorderColor 200 200 0 255
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show # Maps:T11
-	Class Map
-	BaseType "Academy" "Crematorium" "Precinct" "Springs"
+Show # %TB-Uniques-T2-Wep
+	BaseType "Granite Flask" "Fiend Dagger" "Imperial Staff" "Carnal Sceptre" "Siege Axe" "Abyssal Axe" "Sacrificial Garb" "Ritual Sceptre" "Judgement Staff" "Vaal Sceptre" "Imperial Maul" "Steelhead" "Carnal Sceptre" "Terror Maul"
+	Rarity Unique
 	SetFontSize 42
-	PlayAlertSound 4 300
-#	SetBorderColor 0 0 0 255
-#	SetBackgroundColor 255 255 255 255
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
 
-Show # Maps:T12
-	Class Map
-	BaseType "Arsenal" "Overgrown Ruin" "Shipyard" "Village Ruin"
-	SetFontSize 43
-	PlayAlertSound 4 300
-	SetTextColor 0 0 0 255
-	SetBackgroundColor 200 200 200 255
-	SetBorderColor 0 0 0 255
+Show # %TB-Uniques-T2-Arm
+	BaseType "Jingling Spirit Shield" "Savant's Robe" "Gladiator Plate" "Vaal Regalia" "Sacrificial Garb" "Archon Kite Shield" "Legion Gloves" "Raven Mask" "Champion Kite Shield" "Nightmare Bascinet" "Clasped Mitts" "Wyrmscale Doublet"
+	Rarity Unique
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+Show # %TB-Uniques-T2-Misc
+	BaseType "Gold Ring" "Crystal Belt" "Citrine Amulet"
+	Rarity Unique
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 6 300                 # DROPSOUND:	 T1 Drop
+
+#------------------------------------
+#   [1704] Multi-Unique bases.
+#------------------------------------
+# These bases have multiple uniques. One of the uniques, is a high value one
+# While others are cheap. We give them a high quality display, while making a normal unique
+# Sound to prevent false excitement.
+
+Show # %TB-MultiBase-Uniques
+	BaseType "Ebony Tower Shield" "Onyx Amulet" "Goathide Boots" "Two-Stone Ring"
+	Rarity Unique
+	SetFontSize 42
+	SetTextColor 0 0 0 255               # TEXTCOLOR:	 Cosmetic: Black Text
+	SetBorderColor 0 0 0 255             # BORDERCOLOR:	 Cosmetic: Highlight good drops
+	SetBackgroundColor 175 96 37 255     # BACKGROUND:	 T2 unique
+	PlayAlertSound 3 300                 # DROPSOUND:	 Random uniques, 20qual gems
+
+#------------------------------------
+#   [1705] Prophecy-Material Uniques
+#------------------------------------
+
+Show # %TB-Uniques-Fated
+	BaseType "Iron Ring" "Coral Ring" "Jade Amulet" "Plate Vest" "Ornate Sword" "Scholar Boots" "Iron Staff" "Spiraled Wand" "Sledgehammer" "Long Bow" "Crude Bow" "Royal Bow" "Woodsplitter" "Jade Hatchet" "Painted Buckler" "Plank Kite Shield" "War Buckler" "Gilded Sallet" "Iron Hat" "Vine Circlet" "Goathide Gloves" "Coral Amulet" "Fire Arrow Quiver" "Serrated Arrow Quiver" "Death Bow"
+	Rarity Unique
+	SetFontSize 40
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 100 37 255 200        # BORDERCOLOR:	 Cosmetic: Fated Uniques
+	SetBackgroundColor 15 0 25 255       # BACKGROUND:	 Uniques: Prophecy Base
+	PlayAlertSound 3 300                 # DROPSOUND:	 Random uniques, 20qual gems
+
+#------------------------------------
+#   [1706] Random Uniques
+#------------------------------------
+
+Show # T3
+	Rarity Unique
+	SetFontSize 40
+	SetTextColor 175 96 37 255           # TEXTCOLOR:	 Uniques
+	SetBorderColor 175 96 37 255         # BORDERCOLOR:	 Unique Item
+	SetBackgroundColor 0 0 0 255         # BACKGROUND:	 T6-10 maps, currency, talismans
+	PlayAlertSound 3 300                 # DROPSOUND:	 Random uniques, 20qual gems
+
+#===============================================================================================================
+# [[1800]] Exceptions - Quest Items etc.
+#===============================================================================================================
 
 
-Show # Maps:T13
-	Class Map
-	BaseType "Courtyard" "Excavation" "Wasteland" "Waterways"
+Show
+	Class Quest
+	BaseType "Shaper's Orb"
 	SetFontSize 44
-	PlayAlertSound 4 300
-	SetTextColor 0 0 0 255
-	SetBackgroundColor 200 200 200 255
-	SetBorderColor 0 0 0 255
-
-Show # Maps:T14
-	Class Map
-	BaseType "Shrine" "Conservatory" "Palace"
-	SetFontSize 45
-	PlayAlertSound 4 300
-	SetTextColor 0 0 0 255
-	SetBackgroundColor 200 200 200 255
-	SetBorderColor 0 0 0 255
-
-Show # Maps:T15
-	Class Map
-	BaseType "Abyss" "Colosseum" "Core"
-	SetFontSize 45
-	PlayAlertSound 6 300
-	SetTextColor 0 0 0 255
-	SetBorderColor 0 0 0 255
-	SetBackgroundColor 255 255 255 255
-
-# This shouldn't be happening, but just in case:
+	SetBorderColor 74 230 58             # BORDERCOLOR:	 Labyrinth, Quest, Shaper Orbs
+	PlayAlertSound 2 300                 # DROPSOUND:	 Value Drop: Currency, fragments
 
 Show
-	Class Map
-	PlayAlertSound 4 300
-	SetFontSize 44
-
-#----------------------------------------------------
-# 0203 # MAP FRAGMENTS
-#----------------------------------------------------
-
-Show
-	BaseType "Mortal Hope"
-	Class "Map Fragments"
-	PlayAlertSound 6 300
-	SetFontSize 45
-	SetTextColor 0 0 0 255
-	SetBorderColor 0 0 0 255
-	SetBackgroundColor 255 255 255 255
-
-Show
-	BaseType "Sacrifice at Midnight"
-	Class "Map Fragments"
-	PlayAlertSound 4 300
+	Class Quest
 	SetFontSize 40
-	SetBorderColor 255 255 255 255
-	SetTextColor 255 255 255 255
-	SetBackgroundColor 0 0 0 255
+	SetBorderColor 74 230 58             # BORDERCOLOR:	 Labyrinth, Quest, Shaper Orbs
 
-Show
-	Class "Map Fragments"
-	PlayAlertSound 4 300
+#===============================================================================================================
+# [[1900]] OVERRIDE AREA 4 - Insert your custom leveling adjustments here
+#===============================================================================================================
+
+#===============================================================================================================
+# [[2000]] LEVELING - Flasks
+#===============================================================================================================
+
+#------------------------------------
+#   [2001] Hide outdated flasks
+#------------------------------------
+
+Hide #$flask, lvl
+	Class "Life Flask" "Mana Flask"
+	BaseType Flask
+	BaseType Small Medium Large Greater Grand
+	ItemLevel >= 35
+	SetFontSize 20
+
+Hide #$flask, lvl
+	Class "Life Flask" "Mana Flask"
+	BaseType Flask
+	BaseType Giant Colossal Sacred
+	ItemLevel >= 53
+	SetFontSize 20
+
+#------------------------------------
+#   [2002] Hybrid flasks (normal)
+#------------------------------------
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Small"
+	Rarity Normal
+	ItemLevel <= 15
 	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-#------------------------------------------------------------------------
-# Section: 0300 # CURRENCY
-#------------------------------------------------------------------------
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Medium"
+	Rarity Normal
+	ItemLevel <= 25
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-#----------------------------------------------------
-# 0301 # TOP TIER: DIVINE, EXALTED (alos eternal, but meh)
-#----------------------------------------------------
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Large"
+	Rarity Normal
+	ItemLevel <= 35
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
-	BaseType "Eternal Orb" "Divine Orb" "Exalted Orb" "Albino Rhoa Feather"
-	SetTextColor 255 0 0 255
-	SetBorderColor 255 0 0 255
-	SetBackgroundColor 255 255 255 255
-	PlayAlertSound 6 300
-	SetFontSize 45
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Colossal"
+	Rarity Normal
+	ItemLevel <= 45
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-#----------------------------------------------------
-# 0302 # HIGH TIER: FROM JEWELLER'S TO REGAL
-#----------------------------------------------------
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Sacred"
+	Rarity Normal
+	ItemLevel <= 55
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
-	BaseType "Regal Orb" "Orb of Regret" "Chaos Orb" "Blessed Orb" "Gemcutter's Prism" "Orb of Fusing" "Orb of Scouring" "Orb of Alchemy" "Glassblower's Bauble" "Vaal Orb" "Cartographer's Chisel"
-	SetBackgroundColor 213 159 15
-	SetTextColor 0 0 0
-	SetBorderColor 0 0 0
-	PlayAlertSound 1 300
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Hallowed"
+	Rarity Normal
+	ItemLevel <= 67
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+#------------------------------------
+#   [2003] Hybrid flasks (magic)
+#------------------------------------
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Small"
+	Rarity Magic
+	ItemLevel <= 15
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Medium"
+	Rarity Magic
+	ItemLevel <= 25
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Large"
+	Rarity Magic
+	ItemLevel <= 35
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Colossal"
+	Rarity Magic
+	ItemLevel <= 45
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Sacred"
+	Rarity Magic
+	ItemLevel <= 55
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class "Hybrid Flask"
+	BaseType "Hallowed"
+	Rarity Magic
+	ItemLevel <= 66
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+#------------------------------------
+#   [2004] Life/Mana Flask - Normal (Kudos to Antnee)
+#------------------------------------
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Small"
+	Rarity Normal
+	ItemLevel <= 5
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Medium"
+	Rarity Normal
+	ItemLevel <= 8
+	ItemLevel >= 3
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Large"
+	Rarity Normal
+	ItemLevel <= 12
+	ItemLevel >= 5
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Greater"
+	Rarity Normal
+	ItemLevel <= 18
+	ItemLevel >= 12
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Grand"
+	Rarity Normal
+	ItemLevel <= 24
+	ItemLevel >= 18
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Giant"
+	Rarity Normal
+	ItemLevel <= 30
+	ItemLevel >= 24
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Colossal"
+	Rarity Normal
+	ItemLevel <= 37
+	ItemLevel >= 30
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Sacred"
+	Rarity Normal
+	ItemLevel <= 42
+	ItemLevel >= 36
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Hallowed"
+	Rarity Normal
+	ItemLevel <= 48
+	ItemLevel >= 42
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Sanctified"
+	Rarity Normal
+	ItemLevel <= 55
+	ItemLevel >= 48
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Divine"
+	Rarity Normal
+	ItemLevel <= 66
+	ItemLevel >= 60
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Eternal"
+	Rarity Normal
+	ItemLevel <= 66
+	ItemLevel >= 65
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+#------------------------------------
+#   [2005] Life/Mana Flask - Magic (Kudos to Antnee)
+#------------------------------------
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Small"
+	Rarity Magic
+	ItemLevel <= 5
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Medium"
+	Rarity Magic
+	ItemLevel <= 8
+	ItemLevel >= 3
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Large"
+	Rarity Magic
+	ItemLevel <= 12
+	ItemLevel >= 5
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Greater"
+	Rarity Magic
+	ItemLevel <= 18
+	ItemLevel >= 12
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Grand"
+	Rarity Magic
+	ItemLevel <= 24
+	ItemLevel >= 18
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Giant"
+	Rarity Magic
+	ItemLevel <= 30
+	ItemLevel >= 24
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Colossal"
+	Rarity Magic
+	ItemLevel <= 37
+	ItemLevel >= 30
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Sacred"
+	Rarity Magic
+	ItemLevel <= 42
+	ItemLevel >= 36
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Hallowed"
+	Rarity Magic
+	ItemLevel <= 48
+	ItemLevel >= 42
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Sanctified"
+	Rarity Magic
+	ItemLevel <= 55
+	ItemLevel >= 48
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Divine"
+	Rarity Magic
+	ItemLevel <= 67
+	ItemLevel >= 60
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$flask, lvl
+	Class Flasks
+	BaseType "Eternal"
+	Rarity Magic
+	ItemLevel <= 66
+	ItemLevel >= 65
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+#------------------------------------
+#   [2006] Show remaining flasks
+#------------------------------------
+
+Show #$flask, lvl
+	BaseType Flask
+	Rarity <= Magic
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+
+#===============================================================================================================
+# [[2100]] LEVELING - RARES
+#===============================================================================================================
+
+#------------------------------------
+#   [2101] Leveling rares - tier list
+#------------------------------------
+
+Show #$leveling, small, autosmall, bhg, great
+	LinkedSockets >= 4
+	Rarity Rare
+	ItemLevel < 65
 	SetFontSize 40
+	SetBorderColor 100 255 255 255       # BORDERCOLOR:	 Leveling: 4-linked rare
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
 
-#	200 158 130 this is the old background color, if you like it more use it instead
-
-#----------------------------------------------------
-# 0303 # MEDIUM-LOW ORBS
-#----------------------------------------------------
-
-Show
-	BaseType "Orb of Chance" "Orb of Alteration" "Chromatic Orb" "Jeweller's Orb"
-	SetTextColor 190 178 135 255
-	SetBorderColor 190 178 135 135
-	SetFontSize 38
-
-Show
-	Class Currency
-	BaseType "Perandus"
-	SetTextColor 255 178 135 255
-	SetBorderColor 255 178 135 135
-	SetFontSize 38
-
-#----------------------------------------------------
-# 0304 # BOTTOM TIER: LOW ORB VARIATIONS
-#----------------------------------------------------
-
-Show
-	BaseType "Portal Scroll" "Scroll of Wisdom"
-	SetTextColor 170 158 130 220
-	SetBorderColor 0 0 0 255
-
-Show
-	BaseType "Scroll Fragment"
-	SetTextColor 170 158 130 165
-	SetFontSize 29
-
-#	170 158 130	default currency color
-
-#----------------------------------------------------
-# 0305 # DIVINATION CARD TIER LIST
-#----------------------------------------------------
-# Old puple color: "SetTextColor 150 50 190"
-
-#TIER 1: 15C+++
-
-Show
-	Class "Divination"
-	BaseType "House of Mirrors" "Wealth and Power" "The Dragon's Heart" "The Brittle Emperor" "The Wind" "Celestial Justicar" "Dark Mage" "Doctor" "Fiend" "The Queen" "The Artist" "The Last One Standing" "The Artist" "Bowyer's Dream" "Hunter's Reward" "The Thaumaturgist"  "The Warlord" "The Offering" "The Ethereal" "The Dapper Prodigy" "The Spoiled Prince" "Abandoned Wealth" "The Enlightened" "Last Hope"
-	SetFontSize 45
-	SetBorderColor 0 0 255 255
-	SetBackgroundColor 255 255 255 255
-	SetTextColor 0 0 255 255
-	PlayAlertSound 6 300
-
-#TIER 2: ~7C+
-
-Show
-	Class "Divination"
-	BaseType "The Aesthete" "The Risk" "Chains that Bind" "The Hunger" "The Incantation" "The Pact" "The Road to Power" "The Watcher" "The Betrayal" "The Pack Leader" "Merciless Armament" "Pride Before the Fall" "The King's Heart" "The Surveyor" "Rats" "Tranquillity" "The Vast" "Vinia's Token" "Chaotic Disposition" "The Sigil"
-	SetFontSize 44
-	SetBorderColor 0 0 255 255
-	SetBackgroundColor 0 210 255 255
-	SetTextColor 0 0 0
-	PlayAlertSound 1 300
-
-#TIER 3: ~2C+
-
-Show
-	Class "Divination"
-	BaseType "Glimmer" "The Demoness" "The Drunken Aristocrat" "The Fletcher" "Avenger" "Time-Lost Relic" "Earth Drinker" "The Arena Champion" "The Mercenary" "The Trial" "Grave Knowledge" "The Siren" "Encroaching Darkness" "Doedre's Madness" "Humility" "The Union"   "Lucky Connections" "Jack in the Box" "The Inventor" "Hope" "The Hoarder" "Gemcutter's Promise" "The Explorer" "Anarchy's Price"   "Blind Venture" "The Cartographer" "Scholar of the Seas" "Volatile Power" "Lost Worlds" "The Body" "Birth of the Three"
-	SetFontSize 40
-	SetBorderColor 0 110 255 255
-	SetBackgroundColor 110 215 230 235
-	SetTextColor 0 0 0
-	PlayAlertSound 1 300
-
-#TIER 5: TRASH-tier. <1alt
-
-Show
-	Class "Divination"
-	BaseType "Carrion Crow" "Other Cheek"
-	SetBackgroundColor 175 215 230 200
-	SetTextColor 0 0 0
-	SetBorderColor 0 0 0
-	SetFontSize 32
-
-#TIER 4: Rest. <2c
-
-Show
-	Class "Divination"
-	SetBackgroundColor 145 215 230 225
-	SetBorderColor 0 100 215 255
-	SetTextColor 0 0 0
-	SetFontSize 38
-	PlayAlertSound 1 300
-
-#----------------------------------------------------
-# 0306 # REST
-#----------------------------------------------------
-
-Show
-	Class Currency
-	SetBorderColor 0 0 0 255
-
-Show
-	Class Stackable Currency
-	SetBorderColor 0 0 0 255
-
-#------------------------------------------------------------------------
-# Section: 0400 # SOCKET/LINK BASED stuff
-#------------------------------------------------------------------------
-# 5-links (6 links are handled at the start)
-Show
-	LinkedSockets 5
-	SetBorderColor 0 255 255
-	PlayAlertSound 1 300
-	SetFontSize 39
-
-# 6-Sockets
-Show
-	Sockets 6
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250
-	SetFontSize 40
-	PlayAlertSound 1 300
-
-Show
-	Sockets 6
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250
-	SetFontSize 39
-	PlayAlertSound 1 300
-
-# Corrupted items with white sockets for offhand gem leveling.
-Show
-	Class Wands Daggers One Hand Shields Thrusting Sceptre Claws
-	Sockets >= 3
-	SocketGroup W
-
-#------------------------------------------------------------------------
-# Section: 0500 # SKILL GEMS
-#------------------------------------------------------------------------
-
-Show
-	Class Gem
-	BaseType "Empower" "Enlighten"
-	Quality >= 15
-	SetBorderColor 30 150 180 255
-	SetTextColor 30 150 180 255
-	SetBackgroundColor 255 255 255 255
-	PlayAlertSound 6 300
-	SetFontSize 45
-
-Show
-	Class Gem
-	Quality = 20
-	SetBorderColor 30 150 180 255
-	SetTextColor 30 150 180 255
-	SetBackgroundColor 255 255 255 255
-	PlayAlertSound 6 300
-	SetFontSize 45
-
-Show # Drop only good gems
-	Class Gem
-	BaseType "Portal" "Empower" "Enlighten" "Enhance" "Vaal Haste"
-	SetBorderColor 30 150 180
-	PlayAlertSound 6 300
-	SetFontSize 41
-
-Show # Drop only meh gems
-	Class Gem
-	BaseType "Detonate Mines" "Added Chaos Damage" "Vaal"
-	SetBorderColor 30 150 180 150
-	SetFontSize 38
-
-Show
-	Class "Gems"
-	Quality >= 15
-	SetBorderColor 30 150 180 255
-	SetFontSize 41
-	PlayAlertSound 1 300
-
-Show
-	Class "Gems"
-	Quality > 0
-	SetBorderColor 30 150 180 155
-	SetFontSize 38
-
-Show
-	Class Gems
-
-#------------------------------------------------------------------------
-# Section: 0600 # RARE ITEM HIGHLIGHTING
-#------------------------------------------------------------------------
-
-#------------------------------------------------------------------------
-# 060a # RARES SUITABLE FOR ENDGAME CRAFTING
-#------------------------------------------------------------------------
-
-Show #$topcrafting, 84
-	Rarity Rare
-	ItemLevel >= 84
-	BaseType "Void Sceptre" "Opal Sceptre" "Profane Wand" "Prophecy Wand" "Opal Wand" "Sambar Sceptre" "Imbued Wand" "Vaal Regalia" "Sorcerer Boots" "Sorcerer Gloves" "Hubris Circlet" "Saintly Chainmail" "Titanium Spirit Shield" "Harmonic Spirit Shield" "Fossilised Spirit Shield" "Titan Gauntlets" "Slink Gloves" "Eternal Burgonet" "Lion Pelt" "Titan Greaves" "Slink Boots"
-	SetTextColor 255 190 0
-	SetBorderColor 255 255 0 255
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 38
-
-Show #$topcrafting, 84
-	Rarity Rare
-	Class Rings Amulet Belts
-	BaseType "Onyx" "Ruby" "Sapphire" "Topaz" "Two-Stone" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash"
-	ItemLevel >= 84
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetBorderColor 255 255 0 255
-	SetFontSize 40
-
-Show #$topcrafting, 83
-	Rarity Rare
-	BaseType "Lion Sword" "Vaal Greatsword" "Vaal Axe" "Coronal Maul" "Exquisite Blade" "Fleshripper" "Harbinger Bow" "Gemini Claw" "Ambusher" "Platinum Kris"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-
-Show #$topcrafting, 83
-	Rarity Rare
-	BaseType "Demon Dagger" "Imperial Skean" "Vaal Hatchet" "Runic Hatchet" "Behemoth Mace" "Eternal Sword" "Tiger Hook" "Eclipse Staff" "Maelstr" "Judgement Staff" "Jewelled Foil" "Dragoon Sword"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-
-Show #$topcrafting, 83
-	Rarity Rare
-	BaseType "Sai"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	Class Daggers
-	SetFontSize 38
-
-#----------------------------------------------------
-# 060b # RARE RINGS, AMULETS, JEWELS, BELTS
-#----------------------------------------------------
-#Amulets, rings and jewels don't care much about the droplevel
-#Also they're small, making them the ideal loottype. Always highlight them in a special (lime-green) hue
-
-Show #$great
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetBorderColor 25 180 25
-	SetFontSize 39
-	Class Rings Amulets Belts Jewel
-	Rarity Rare
-
-Show #$great
-	Class Rings Amulets Belts Jewel
-	Rarity Rare
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 39
-	SetBorderColor 25 180 25
-
-#----------------------------------------------------
-# 060c # DROP LEVEL 69+ ITEMS ARE ALWAYS PRIORITIZED RARES
-#----------------------------------------------------
-
-Show #$good, ilvl69, small
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$good, ilvl69, small
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good, ilvl69
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, ilvl69, small
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good, ilvl69, small
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$good, ilvl69
-	Rarity Rare
-	DropLevel >= 69
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#----------------------------------------------------
-# 0601 # RARE DAGGERS
-#----------------------------------------------------
-#GOOD DAGGERS
-#----------------------------------------------------
-
-Show #$good, autosmall
-	Class Daggers
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	Class Daggers
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#In addition highlight rare's with high base attack speed / crit - for CoC and caster dagger variations
-#----------------------------------------------------
-
-Show #$good, autosmall
-	Class Daggers
-	BaseType "Skean"
-	Rarity Rare
-	ItemLevel >= 75
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	SetTextColor 255 190 0
-
-Show #$good, autosmall
-	Class Daggers
-	BaseType "Skean"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#BAD DAGGERS
-#----------------------------------------------------
-#Daggers small enough to be decent loot for vendoring. Never highlight/hide bad daggers
-
-#----------------------------------------------------
-# 0602 # RARE CLAWS
-#----------------------------------------------------
-#GOOD CLAWS
-#----------------------------------------------------
-#At least earlier most claws were vendor trash
-#The RARELY worthwhile rares are usually high level claws or some specific base types (such as great white claw)
-#Still as 4-slot items they are borderline useful and will not be unhighlighted unless they have depressingly low droplevel (shouldn't be happening too often)
-
-Show #$good, autosmall
-	Class Claws
-	Rarity Rare
-	DropLevel >= 65
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	Class Claws
-	Rarity Rare
-	DropLevel >= 65
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#BAD CLAWS
-#----------------------------------------------------
-
-Show #$bad, autosmall
-	Class Claws
-	Rarity Rare
-	DropLevel < 50
-	ItemLevel >= 75
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	SetFontSize 28
-	SetTextColor 255 190 0
-
-Show #$bad, autosmall
-	Class Claws
-	Rarity Rare
-	DropLevel < 50
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0603 # RARE WANDS
-#----------------------------------------------------
-
-#As spellcaster weapons, wands are good pick-ups if they're rare
-#High level wands get highlighted, because of their multi-purpose potential
-
-#GOOD WANDS
-#----------------------------------------------------
-
-Show #$good, autosmall
-	Class Wands
-	Rarity Rare
-	DropLevel >= 59
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	Class Wands
-	Rarity Rare
-	DropLevel >= 59
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#BAD WANDS
-#----------------------------------------------------
-#Wands small enough to be decent loot for vendoring. Never bad-highlight/hide wands
-
-#----------------------------------------------------
-# 0604 # RARE SWORDS
-#----------------------------------------------------
-
-#Worthwhile swords are physical or elemental weapons
-#First one require a decent droplevel, second one the highest attack speed base types
-#We can bad-highlight the rest, because they are way too clunky
-#Same applies to the "thrusting swords" type, that is also filtered here, though they are easier to carry due to their consistently small size
-
-#GOOD SWORDS
-#----------------------------------------------------
-
-Show #$good, small
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, small
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel >= 60
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#HIGH ATTACK SPEED LOWER LEVEL BASES
-#These are some of the best ele ST weapons bases.
-
-Show #$good
-	Class "One Hand"
-	BaseType "Jewelled Foil" "Spiraled Foil"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	Class "One Hand"
-	BaseType "Jewelled Foil" "Spiraled Foil"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#BAD SWORDS
-#One Hand swords with with such low base drop level are rarely anything interesting.
-#High attack speed bases for viable ele weapons are filtered out above.
-
-Show #$bad, small
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 3
-	Width <= 1
-	SetFontSize 28
-
-Show #$bad
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, small
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 3
-	Width <= 1
-	SetFontSize 28
-
-Show #$bad, small
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 2
-	Width <= 2
-	SetFontSize 28
-
-Show #$bad
-	Class "One Hand Swords"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0605 # RARE AXES&MACES (1H)
-#----------------------------------------------------
-#1H-Axes are only used as physical weapons and only if they roll really well. That's why a high droplevel is required for an axe to be recommended
-#GOOD 1H AXES&MACES
-
-Show #$good
-	Class "One Hand Axes"
-	BaseType "Siege Axe" "Vaal Hatchet"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	Class "One Hand Axes"
-	BaseType "Siege Axe" "Vaal Hatchet"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, small
-	Class "One Hand Maces"
-	Rarity Rare
-	DropLevel >= 66
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good
-	Class "One Hand Maces"
-	Rarity Rare
-	DropLevel >= 66
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, small
-	Class "One Hand Maces"
-	Rarity Rare
-	DropLevel >= 66
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$good
-	Class "One Hand Maces"
-	Rarity Rare
-	DropLevel >= 66
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#----------------------------------------------------
-#BAD 1H MACES/AXES
-#Anything with a <50lvl base won't be a priority pickup while maping.
-
-Show #$bad, small
-	Class "One Hand Maces" "One Hand Axes"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 3
-	Width <= 1
-	SetFontSize 28
-
-Show #$bad
-	Class "One Hand Maces" "One Hand Axes"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, small
-	Class "One Hand Maces" "One Hand Axes"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 3
-	Width <= 1
-	SetFontSize 28
-
-Show #$bad
-	Class "One Hand Maces" "One Hand Axes"
-	Rarity Rare
-	DropLevel <= 54
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0606 # RARE SCEPTRES
-#----------------------------------------------------
-#Any sceptre can be good, however some sceptres are better pickups, because of their base or their implicit
-#GOOD SCEPTRES
-
-Show #$good
-	Class "Sceptres"
-	Rarity Rare
-	DropLevel >= 64
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	Class "Sceptres"
-	Rarity Rare
-	DropLevel >= 64
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#Lets's also highlight the high base spell damage sceptres
-
-Show #$good, spelldamage
-	BaseType "Opal Sceptre" "Crystal Sceptre"
-	Class "Sceptres"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, spelldamage
-	BaseType "Opal Sceptre" "Crystal Sceptre"
-	Class "Sceptres"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#BAD SCEPTRES
-#Noone here :O
-
-#----------------------------------------------------
-# 0607 # RARE STAVES
-#----------------------------------------------------
-
-#Now staves are a bit tricky.
-#They can roll high spellcaster bonuses or +3 to gems, making any staff potentially useful.
-#They can also roll high base damage stats
-#Still good staves are rare and all of them are clunky, I'll only highlight the very good base types
-
-Show #$good, clunky
-	Class "Staves"
-	Rarity Rare
-	DropLevel >= 68
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, clunky
-	Class "Staves"
-	Rarity Rare
-	DropLevel >= 68
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, clunky
-	Class "Staves"
-	BaseType "Lathi"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, clunky
-	BaseType "Lathi"
-	Class "Staves"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#BAD STAVES
-#If you're playing a caster or think it's a good idea feel free to remove the following parts
-#However, chances are you won't find anything amazing around here.
-
-Show #$bad, clunky
-	Class "Staves"
-	Rarity Rare
-	DropLevel <= 56
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, clunky
-	Class "Staves"
-	Rarity Rare
-	DropLevel <= 56
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0608 # RARE TWO HAND SWORDS + MACES + AXES
-#----------------------------------------------------
-#These are usually pretty bad
-#High drop level bases have a small chance to be decent
-#Everything else is usually too clunky
-
-Show #$good, clunky
-	Class "Two Hand"
-	Rarity Rare
-	DropLevel >= 64
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, clunky
-	Class "Two Hand"
-	Rarity Rare
-	DropLevel >= 64
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#BAD TWO HANDED WEAPONS
-#Chances are you won't find anything amazing around here.
-
-Show #$bad, clunky
-	Class "Two Hand"
-	Rarity Rare
-	DropLevel <= 56
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, clunky
-	Class "Two Hand"
-	Rarity Rare
-	DropLevel <= 56
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0609 # RARE BOWS
-#----------------------------------------------------
-#With the huge demand for good bows, it's worth checking out quite some of those
-
-Show #$good, clunky
-	Class "Bows"
-	Rarity Rare
-	DropLevel >= 62
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, clunky
-	Class "Bows"
-	Rarity Rare
-	DropLevel >= 62
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#BAD BOWS!
-#----------------------------------------------
-#The low level one are usually just clunky
-
-Show #$bad, clunky
-	Class "Bows"
-	Rarity Rare
-	DropLevel <= 50
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, clunky
-	Class "Bows"
-	Rarity Rare
-	DropLevel <= 50
-	ItemLevel >= 65
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0610 # RARE QUIVERS
-#----------------------------------------------------
-#All quivers are decent pickups. However, there are some quiver-types that are just much more better.
-
-Show #$good
-	BaseType "Spike-Point Arrow Quiver" "Broadhead Arrow Quiver" "Two-Point Arrow Quiver"
-	Class "Quivers"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	BaseType "Spike-Point Arrow Quiver" "Broadhead Arrow Quiver" "Two-Point Arrow Quiver"
-	Class "Quivers"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#----------------------------------------------------
-# 0611 # RARE GLOVES, HELMETS, BOOTS
-#----------------------------------------------------
-#Most bases are getting highlighted (around 75% of all drops)
-#VERY low bases are getting negative highlighting (likely <1% of all drops)
-
-Show #$good, autosmall
-	Class "Gloves" "Boots" "Helmets"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 44
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	Class "Gloves" "Boots" "Helmets"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 44
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$bad, autosmall
-	Class "Gloves" "Boots" "Helmets"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel <= 15
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	SetFontSize 28
-
-Show #$bad, autosmall
-	Class "Gloves" "Boots" "Helmets"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel <= 15
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0612 # RARE SHIELDS
-#----------------------------------------------------
-#Shields are by far the hardest category to sort
-#Here's my philosophy:
-
-#1) Highlight high droplevel/itemlevel bases, no matter what type of shield they are, to perform some pre-sorting
-#----------------------------------------------------
-
-Show #$good, small
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 66
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$good
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 66
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good, small
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 66
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$good
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 66
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#2) Energy shields however are quite decent pickups, even if the droplevel is low, let's add this!
-#----------------------------------------------------
-
-Show #$good, autosmall
-	BaseType "Spirit Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 55
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	BaseType "Spirit Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 55
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#3) Still display the low level spirit shields as "neutral" they are small and nice
-#-----------------------------------------------------
-
-Show #$ok, autosmall
-	BaseType "Spirit Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetFontSize 31
-	SetBorderColor 150 150 150 200
-
-Show #$ok, autosmall
-	BaseType "Spirit Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	SetFontSize 31
-	SetBorderColor 150 150 150 200
-
-#4) The Kite Shields can be quite decent too, let's highlight the good ones!
-#-----------------------------------------------------
-
-Show #$good
-	BaseType "Branded Kite Shield" "Champion Kite Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	BaseType "Branded Kite Shield" "Champion Kite Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-#5) Bucklers and Spiked shields are OK-ish pickups due to their small size
-#-----------------------------------------------------
-
-Show #$good, autosmall
-	BaseType "Buckler" "Spiked Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 60
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-Show #$good, autosmall
-	BaseType "Buckler" "Spiked Shield"
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 60
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 150 150 150
-
-#6) Now lets mark some of the remaining low level shields as bad
-#-----------------------------------------------------
-
-Show #$bad, small
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel <= 50
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 2
-	Width <= 2
-	SetFontSize 28
-
-Show #$bad
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel <= 50
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad, small
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel <= 50
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 150 150 150 150
-	Height <= 2
-	Width <= 2
-	SetFontSize 28
-
-Show #$bad
-	Class "Shields"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel <= 50
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#----------------------------------------------------
-# 0613 # RARE BODY ARMOR
-#----------------------------------------------------
-#Highlight high level tiers
-#Mark really low level ones. Easy enough.
-
-Show #ok, hybrid
-	BaseType "Dragonscale Doublet" "Blood Raiment" "Full Dragonscale" "Elegant Ringmail" "Varnished Coat" "Conquest Chainmail" "Desert Brigandine"
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 60
-	SetTextColor 255 190 0
-	SetBorderColor 0 0 0
-
-Show #ok, hybrid
-	BaseType "Dragonscale Doublet" "Blood Raiment" "Full Dragonscale" "Elegant Ringmail" "Varnished Coat" "Conquest Chainmail" "Desert Brigandine"
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 60
-	SetBorderColor 0 0 0
-
-Show #$good
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel >= 60
-	SetTextColor 255 190 0
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$good
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel >= 60
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 35
-	SetBorderColor 0 0 0
-
-Show #$bad
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 75
-	DropLevel <= 47
-	SetTextColor 255 190 0
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-Show #$bad
-	Class "Body Armour"
-	Rarity Rare
-	ItemLevel >= 65
-	DropLevel <= 47
-	SetBackgroundColor 120 20 20 150
-	SetBorderColor 0 0 0 220
-	SetFontSize 28
-
-#------------------------------------------------------------------------
-# 0614 # RARES - LEVELING SPECIFIC RULES
-#------------------------------------------------------------------------
-
-
-Show #$leveling, autosmall, bhg, great
+Show #$leveling, small, autosmall, bhg, great
 	Class "Boots"
-	ItemLevel < 30
 	Rarity Rare
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 39
-	SetBorderColor 25 180 25
+	ItemLevel < 30
+	SetFontSize 40
+	SetBorderColor 220 220 220           # BORDERCOLOR:	 Leveling: very useful rares
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
 
-Show #$leveling, autosmall, bhg, great
+Show #$leveling, small, autosmall, bhg, great
 	Class "Boots" "Helmets" "Gloves"
-	ItemLevel < 65
 	Rarity Rare
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 39
-	SetBorderColor 25 180 25
+	ItemLevel < 65
+	SetFontSize 38
+	SetBorderColor 220 220 220           # BORDERCOLOR:	 Leveling: very useful rares
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
+
+Show #$leveling, good, exception
+	Class "Sceptres" "Daggers" "Wands"
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 38
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 225      # BACKGROUND:	 Rares - Basetype - Great
 
 Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
 	Rarity Rare
 	ItemLevel < 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
+	SetFontSize 40
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
 	Rarity Rare
 	ItemLevel < 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
+	SetFontSize 40
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, good
 	Rarity Rare
 	ItemLevel < 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
+	SetFontSize 38
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 5
 	Rarity Rare
 	ItemLevel < 15
-	DropLevel > 5
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
+	SetFontSize 38
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 5
 	Rarity Rare
 	ItemLevel < 15
-	DropLevel > 5
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
+	SetFontSize 38
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, good
+	DropLevel > 5
 	Rarity Rare
 	ItemLevel < 15
-	DropLevel > 5
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 20
-	DropLevel > 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 20
-	DropLevel > 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 20
-	DropLevel > 10
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 25
-	DropLevel > 15
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 25
-	DropLevel > 15
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 25
-	DropLevel > 15
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 30
-	DropLevel > 20
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 30
-	DropLevel > 20
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 30
-	DropLevel > 20
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 35
-	DropLevel > 25
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 35
-	DropLevel > 25
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 35
-	DropLevel > 25
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 40
-	DropLevel > 30
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 40
-	DropLevel > 30
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 40
-	DropLevel > 30
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 45
-	DropLevel > 35
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 45
-	DropLevel > 35
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 45
-	DropLevel > 35
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 50
-	DropLevel > 40
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 50
-	DropLevel > 40
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 50
-	DropLevel > 40
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 55
-	DropLevel > 45
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 55
-	DropLevel > 45
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 55
-	DropLevel > 45
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 60
-	DropLevel > 50
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 60
-	DropLevel > 50
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 60
-	DropLevel > 50
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 65
-	DropLevel > 55
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 2
-	Width <= 2
-
-Show #$leveling, small, good
-	Rarity Rare
-	ItemLevel < 65
-	DropLevel > 55
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-
-Show #$leveling, good
-	Rarity Rare
-	ItemLevel < 65
-	DropLevel > 55
-	SetBackgroundColor 30 90 45 230
-	SetFontSize 37
-	ItemLevel < 65
-	SetBorderColor 0 0 0
-
-Show #$leveling, small, good
-	Rarity Rare
-	SetBorderColor 150 150 150
-	Height <= 3
-	Width <= 1
-	SetBackgroundColor 0 0 0 225
 	SetFontSize 35
-	ItemLevel < 65
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
 
 Show #$leveling, small, good
-	Rarity Rare
-	SetBorderColor 150 150 150
-	Height <= 2
 	Width <= 2
-	SetBackgroundColor 0 0 0 225
+	Height <= 2
+	DropLevel > 10
+	Rarity Rare
+	ItemLevel < 20
 	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 10
+	Rarity Rare
+	ItemLevel < 20
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 10
+	Rarity Rare
+	ItemLevel < 20
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 15
+	Rarity Rare
+	ItemLevel < 25
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 15
+	Rarity Rare
+	ItemLevel < 25
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 15
+	Rarity Rare
+	ItemLevel < 25
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 20
+	Rarity Rare
+	ItemLevel < 30
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 20
+	Rarity Rare
+	ItemLevel < 30
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 20
+	Rarity Rare
+	ItemLevel < 30
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 25
+	Rarity Rare
+	ItemLevel < 35
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 25
+	Rarity Rare
+	ItemLevel < 35
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 25
+	Rarity Rare
+	ItemLevel < 35
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 30
+	Rarity Rare
+	ItemLevel < 40
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 30
+	Rarity Rare
+	ItemLevel < 40
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 30
+	Rarity Rare
+	ItemLevel < 40
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 35
+	Rarity Rare
+	ItemLevel < 45
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 35
+	Rarity Rare
+	ItemLevel < 45
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 35
+	Rarity Rare
+	ItemLevel < 45
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 40
+	Rarity Rare
+	ItemLevel < 50
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 40
+	Rarity Rare
+	ItemLevel < 50
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 40
+	Rarity Rare
+	ItemLevel < 50
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 45
+	Rarity Rare
+	ItemLevel < 55
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 45
+	Rarity Rare
+	ItemLevel < 55
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 45
+	Rarity Rare
+	ItemLevel < 55
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 50
+	Rarity Rare
+	ItemLevel < 60
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 50
+	Rarity Rare
+	ItemLevel < 60
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 50
+	Rarity Rare
+	ItemLevel < 60
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 2
+	Height <= 2
+	DropLevel > 55
+	Rarity Rare
 	ItemLevel < 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, small, good
+	Width <= 1
+	Height <= 3
+	DropLevel > 55
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+Show #$leveling, good
+	DropLevel > 55
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 30 90 45 255      # BACKGROUND:	 Rares - Basetype - Good
+
+#------------------------------------
+#   [2102] Leveling rares - remaining rules
+#------------------------------------
+
+Show #$leveling, small
+	Width <= 1
+	Height <= 3
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
+
+Show #$leveling, small
+	Width <= 2
+	Height <= 2
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 35
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
 
 Show #leveling, ok, small
-	Rarity Rare
-	SetBorderColor 150 150 150 200
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 35
-	Height <= 2
 	Width <= 2
+	Height <= 2
+	Rarity Rare
 	ItemLevel < 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
 
 Show #leveling, ok, small
-	Rarity Rare
-	SetBorderColor 150 150 150 200
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 35
-	Height <= 3
 	Width <= 1
+	Height <= 3
+	Rarity Rare
 	ItemLevel < 65
+	SetFontSize 30
+	SetBorderColor 150 150 150 200       # BORDERCOLOR:	 Rares - Size - Small (+OK basetype)
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
 
 Show #leveling, ok
 	Rarity Rare
-	SetBorderColor 0 0 0
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 35
-	ItemLevel < 65
-
-#------------------------------------------------------------------------
-# 0615 # RARES - REMAINING RULES
-#------------------------------------------------------------------------
-#Whatever rares wern't highlighted as good or bad above, will still be displayed
-#Just without any priority highlighting
-
-Show #$small, ok
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBorderColor 150 150 150 200
-	Height <= 2
-	Width <= 2
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-Show #$small, ok
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBorderColor 150 150 150 200
-	Height <= 3
-	Width <= 1
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-Show #$ok
-	Rarity Rare
-	ItemLevel >= 75
-	SetTextColor 255 190 0
-	SetBorderColor 0 0 0
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-Show #$small, ok
-	Rarity Rare
-	SetBorderColor 150 150 150 200
-	Height <= 2
-	Width <= 2
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-Show #$small, ok
-	Rarity Rare
-	SetBorderColor 150 150 150 200
-	Height <= 3
-	Width <= 1
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-Show #$ok
-	Rarity Rare
-	SetBorderColor 0 0 0
-	SetBackgroundColor 0 0 0 225
-	SetFontSize 31
-
-#------------------------------------------------------------------------
-# Section: 0700 # NORMAL AND MAGIC ITEM RULES
-#------------------------------------------------------------------------
-
-#------------------------------------------------------------------------
-# 0701 # 83+ ITEM CRAFTING
-#------------------------------------------------------------------------
-
-Show
-	ItemLevel >= 84
-	BaseType "Void Sceptre" "Opal Sceptre" "Profane Wand" "Prophecy Wand" "Opal Wand" "Sambar Sceptre" "Imbued Wand" "Vaal Regalia" "Sorcerer Boots" "Sorcerer Gloves" "Hubris Circlet" "Saintly Chainmail" "Titanium Spirit Shield" "Harmonic Spirit Shield" "Fossilised Spirit Shield" "Titan Gauntlets" "Slink Gloves" "Eternal Burgonet" "Lion Pelt" "Titan Greaves" "Slink Boots"
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-
-Show # Endgame: Show normal ilvl 83+ rings/amulets
-	Class Rings Amulet Belts
-	BaseType "Onyx" "Ruby" "Sapphire" "Topaz" "Two-Stone" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy Belt" "Amber" "Jade" "Lapis" "Rustic Sash"
-	ItemLevel >= 84
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-
-Show
-	BaseType "Lion Sword" "Vaal Greatsword" "Vaal Axe" "Coronal Maul" "Exquisite Blade" "Fleshripper" "Harbinger Bow" "Gemini Claw" "Ambusher" "Platinum Kris"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-
-Show
-	BaseType "Demon Dagger" "Imperial Skean" "Vaal Hatchet" "Runic Hatchet" "Behemoth Mace" "Eternal Sword" "Tiger Hook" "Eclipse Staff" "Maelstr" "Judgement Staff" "Jewelled Foil" "Dragoon Sword"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	SetFontSize 38
-
-Show
-	BaseType "Sai"
-	ItemLevel >= 83
-	SetBorderColor 255 255 0 255
-	Class Daggers
-	SetFontSize 38
-
-#------------------------------------------------------------------------
-# 0702 # CHROMATIC ORB RECIPE ITEMS
-#------------------------------------------------------------------------
-
-Show
-	SocketGroup RGB
-	SetBackgroundColor 75 75 75
-	SetBorderColor 150 150 150
-	SetFontSize 36
-	Height <= 2
-	Width <= 2
-
-Show
-	SocketGroup RGB
-	SetBackgroundColor 75 75 75
-	SetBorderColor 150 150 150
-	SetFontSize 36
-	Height <= 3
-	Width <= 1
-
-Show
-	SocketGroup RGB
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-
-#------------------------------------------------------------------------
-# 0703 # CHANCE ORB BASES - ADD YOUR ITEMS HERE
-#-------------------------------------------------------------------------
-# ADD ADDITIONAL STUFF HERE IF YOU WANT
-# Enable this line for improved detection of chance bases (like sorcerer boots)
-
-# Sorcerer Boots - Skyforth
-
-### PRIORITY CHANCE ITGEMS ### THESE ITEMS PLAY A SOUND WHEN FOUND ###
-Show # SKYFORTH - You can add your own items here. The items will cause a drop sound.
-	BaseType "Sorcerer Boots"
-	SetBorderColor 0 210 0 210
-	SetTextColor 255 255 255 255
-	Rarity Normal
-	SetFontSize 38
-	PlayAlertSound 7 300
-
-# Occultists' Vestment - Shavronne's Armor
-# Imperial Bow - Windripper (uncommon, rare)/Lionseye (common, cheap)
-# Prophecy wand - Void Battery
-# Judgement Staff - Hegemony's/Pledge of Hands
-# Desert Brigandine - Can be chanced into Lightning Coil	
-	
-### REGULAR CHANCE BASES ###	
-Show # T2 UNIQUES:
-	BaseType "Occultist's Vestment" "Imperial Bow" "Prophecy Wand" "Judgement Staff" "Agate Amulet" "Lapis Amulet" "Amber Amulet" "Leather Belt" "Desert Brigandine"
-	SetBorderColor 0 150 0 150
-	SetTextColor 255 255 255 255
-	Rarity Normal
-
-### LEGACY UNIQUE CHANCE BASES ###
-### THESE UNIQUES CAN ONLY BE CHANCED IN THE CORRECT ZANA-LEAGUE MODS ###
-# Agate Amulet - ANARCHY ONLY - can be chance to voll's in anarchy maps
-# Lapi/Amber Amulet - can be sold together to creater agate amulets
-# Leather belt - NEMESIS only - can be chanced into a headhunter belt!
-	
-Show
-	BaseType "Sacrificial Garb"
-	SetTextColor 255 255 255 255
-	SetBorderColor 0 150 0 150
-	Rarity Normal
-
-
-#------------------------------------------------------------------------
-# 0704 # HIGH LEVEL WHITE RINGS/AMULETS FOR ALCHING
-#-------------------------------------------------------------------------
-
-Show # Endgame: Show normal ilvl 75+ rings/amulets
-	Class Rings Amulet Belts
-	BaseType "Onyx" "Ruby" "Sapphire" "Topaz" "Two-Stone" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy" "Amber" "Jade" "Lapis" "Rustic" "Iron Ring"
-	ItemLevel >= 75
-	SetBorderColor 255 190 0 150
-	Rarity Normal
-	SetFontSize 32
-
-Show # Endgame: Show normal ilvl 60+ rings/amulets
-	Class Rings Amulet Belts
-	BaseType "Onyx" "Ruby" "Sapphire" "Topaz" "Two-Stone" "Diamond" "Prismatic" "Unset" "Gold" "Citrine" "Turquoise" "Agate" "Coral Ring" "Moonstone" "Leather" "Heavy" "Amber" "Jade" "Lapis" "Rustic" "Iron Ring"
-	Rarity Normal
-	SetBorderColor 0 0 0
-	ItemLevel >= 62
-	ItemLevel < 75
-	SetFontSize 32
-
-#------------------------------------------------------------------------
-# 0705 # MAGIC RINGS, AMULETS, BELTS
-#------------------------------------------------------------------------
-#Once we reach mapping we only want to see the top tiers of magic items
-#We still want to see all rings/amulets/belts. They are small and provide alteration shards, if we need those quickly.
-
-Show # Endgame: Show magic rings, amulets and belts. Reduce font size.
-	Class Rings Amulets Belts
-	Rarity Magic
-	ItemLevel >= 62
-	SetFontSize 30
-
-#------------------------------------------------------------------------
-# 0706 # MAGIC JEWELS
-#------------------------------------------------------------------------
-
-Show
-	Class Jewel
-	SetFontSize 36
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 150 200
-
-#------------------------------------------------------------------------
-# 0707 # CHISEL RECIPE ITEMS
-#-------------------------------------------------------------------------
-
-Show # Chisel Recipe: Magic Gavels with 20 qual
-	Quality = 20
-	Rarity Magic
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250
-	SetTextColor 100 100 255 255
-	SetFontSize 38
-
-Show # Chisel Recipe: White Gavels with 20 qual
-	Quality = 20
-	Rarity Normal
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250 255
-	SetTextColor 255 255 255 255
-	SetFontSize 38
-
-Show # Chisel Recipe: Magic Gavels with 18+ qual
-	Quality > 17
-	Rarity Magic
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 135 135 135
-	SetFontSize 36
-
-Show # Chisel Recipe: White Gavels with 15+ qual
-	Quality > 14
-	Rarity Normal
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 135 135 135
-	SetFontSize 36
-
-Show # Chisel Recipe: Magic Gavels with 12+ qual
-	Quality > 11
-	Rarity Magic
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-	SetFontSize 32
-
-Show # Chisel Recipe: White Gavels
-	Rarity Normal
-	BaseType "Gavel" "Rock Breaker" "Stone Hammer"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-	SetFontSize 32
-
-#------------------------------------------------------------------------
-# 0708 # HIGH LEVEL 4+ LINKED ITEMS
-#-------------------------------------------------------------------------
-
-Show # Endgame: Show high level 4 linked items (64-71) in entry level maps/endgame
-	Class "Boots" "Gloves" "Body Armour" "Helmets"
-	DropLevel >= 64
-	ItemLevel < 72
-	LinkedSockets >= 4
-	SetFontSize 32
-	Rarity <= Magic
-
-#------------------------------------------------------------------------
-# 0709 # TOP BASES FOR CRAFTING
-#-------------------------------------------------------------------------
-
-Show # Weapons: Show Ambusher CRAFTING
-BaseType "Ambusher"
-SetFontSize 32
-Rarity <= Magic
-
-Show # Weapons: Show Harbinger Bow CRAFTING
-BaseType "Harbinger Bow"
-SetFontSize 32
-Rarity <= Magic
-
-#
-#Show # Armour: Show Hubris Circlet ES CHANCING/CRAFTING
-#BaseType "Hubris Circlet"
-#SetFontSize 32
-#Rarity <= Magic
-
-#Hide # Weapons: Show Platinum Kris CRAFTING
-#BaseType "Platinum Kris"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Vaal Axe CRAFTING
-#BaseType "Vaal Axe"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Imperial Skean CRAFTING
-#BaseType "Imperial Skean"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Demon Dagger CRAFTING
-#BaseType "Demon Dagger"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Vaal Rapier CRAFTING
-#BaseType "Vaal Rapier"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Jewelled Foil CRAFTING
-#BaseType "Jewelled Foil"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Opal Sceptre CRAFTING
-#BaseType "Opal Sceptre"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Imbued Wand (1.5 speed, 8 crit) CRAFTING
-#BaseType "Imbued Wand"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Weapons: Show Prophecy Wand - CHANCE / CRAFTING
-#BaseType "Prophecy Wand"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Carnal Armour ES/EV CRAFTING
-#BaseType "Carnal Armour"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Saint's Hauberk ES/AR CRAFTING
-#BaseType "Saint's Hauberk"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Saintly Chainmail AR/ES CRAFTING
-#BaseType "Saintly Chainmail"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Triumphant Lamellar EV/AR CRAFTING
-#BaseType "Triumphant Lamellar"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show General's Brigandine AR=EV CRAFTING
-#BaseType "General's Brigandine"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Full Dragonscale AR/EV CRAFTING
-#BaseType "Full Dragonscale"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Assassin's Garb EV CRAFTING
-#BaseType "Assassin's Garb"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Zodiac Leather EV CRAFTING
-#BaseType "Zodiac Leather"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Astral Plate AR CRAFTING
-#BaseType "Astral Plate"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Glorious Plate AR CHANCING/CRAFTING
-#BaseType "Glorious Plate"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Vaal Regalia ES CRAFTING
-#BaseType "Vaal Regalia"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Titanium Spirit Shield ES CHANCING/CRAFTING
-#BaseType "Titanium Spirit Shield"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#Hide # Armour: Show Sorcerer Gloves ES CRAFTING
-#BaseType "Sorcerer Gloves"
-#SetFontSize 32
-#Rarity <= Magic
-#
-#------------------------------------------------------------------------
-# 0710 # MARAKETH WEAPONS
-#-------------------------------------------------------------------------
-# All maraketh weapon bases are visible once their itemlevel is 83+
-# Only gemini's and exquisities are visible earlier (until 77, you kinda dont care about those 78-82)
-# Feel free to enable additional weapons
-
-Show # Maraketh Weapons: Show Gemini Claw (Life/Mana on hit)
-BaseType "Gemini Claw"
-SetFontSize 32
-Rarity <= Magic
-ItemLevel < 78
-
-Show # Maraketh Weapons: Show Exquisite Blade (2h crit blade)
-BaseType "Exquisite Blade"
-SetFontSize 32
-Rarity <= Magic
-ItemLevel < 78
-
-#Show # Maraketh Weapons: Show Profane Wand (Cast Speed)
-#BaseType "Profane Wand"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 78
-
-#Show # Maraketh Weapons: Show Behemoth Mace (1h IAS mace)
-#BaseType "Behemoth Mace"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Sai (1h block dagger)
-#BaseType "Sai"
-#Class Daggers
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 78
-
-#Show # Maraketh Weapons: Show Tiger Hook (1h dodge sword)
-#BaseType "Tiger Hook"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Dragoon Sword (1h bleed foil)
-#BaseType "Dragoon Sword"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Runic Hatchet (1h phys axe)
-#BaseType "Runic Hatchet"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Maraketh Bow (2h MS bow)
-#BaseType "Maraketh Bow"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Eclipse Staff (2h crit staff)
-#BaseType "Eclipse Staff"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 78
-
-#Show # Maraketh Weapons: Show Fleshripper (2h crit axe)
-#BaseType "Fleshripper"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Coronal Maul (2h AOE mace)
-#BaseType "Coronal Maul"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 77
-
-#Show # Maraketh Weapons: Show Sambar Sceptre (1H ele pen sceptre)
-#BaseType "Sambar Sceptre"
-#SetFontSize 32
-#Rarity <= Magic
-#ItemLevel < 78
-
-#------------------------------------------------------------------------
-# 0711 # PRE-ENDGAME 20% QUALITY ITEMS
-#------------------------------------------------------------------------
-#WARNING: IF YOU DON'T LIKE THIS SECTION, REMOVE IT INSTEAD OF SWITCHING SHOW TO HIDE
-
-# You can uncomment these lines to show quality items in maps.
-#Show
-#	Quality = 20
-#	Rarity <= Magic
-#	SetBackgroundColor 75 75 75
-#	SetBorderColor 0 0 0
-
-Show
-	Class "Body Armour" "Helmets" "Gloves" "Boots" "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws"
-	Quality = 20
-	Rarity <= Magic
-	ItemLevel <= 60
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-
-#------------------------------------------------------------------------
-# 0712 # ANIMATE WEAPON SCRIPT (DISABLED)
-#------------------------------------------------------------------------
-# UNCOMMENT THIS SCRIPT TO MAKE IT WORK (remove the # in front of the next 7 lines)
-
-#Show
-#	Class "One Hand" "Two Hand" "Staves" "Daggers" "Thrusting" "Sceptres" "Claws"
-#	Rarity Normal
-#	SetBackgroundColor 0 0 0
-#	SetTextColor 150 0 0
-#	SetBorderColor 150 0 0
-#	SetFontSize 36
-
-#------------------------------------------------------------------------
-# Section: 0800 # FLASKS
-#------------------------------------------------------------------------
-
-Show
-	BaseType "Flask"
-	Rarity Normal
-	Quality = 20
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250
-	SetTextColor 255 255 255 255
-	SetFontSize 38
-
-Show
-	BaseType "Flask"
-	Rarity Magic
-	Quality = 20
-	SetBackgroundColor 75 75 75
-	SetBorderColor 250 250 250
-	SetTextColor 100 100 255 255
-	SetFontSize 38
-
-Show
-	BaseType "Flask"
-	Quality >= 15
-	SetBackgroundColor 75 75 75
-	SetBorderColor 150 150 150
-	SetFontSize 36
-
-Show #
-	BaseType "Quicksilver Flask" "Silver Flask"
-	Rarity <= Magic
-	ItemLevel >= 5
-	ItemLevel < 60
-	Quality >= 1
-	SetFontSize 40
-	SetBorderColor 250 250 250
-	SetBackgroundColor 75 75 75
-
-Show #
-	BaseType "Quicksilver Flask" "Silver Flask"
-	Rarity <= Magic
-	ItemLevel < 60
-	SetFontSize 38
-	SetBorderColor 150 150 150
-	SetBackgroundColor 75 75 75
-
-Show
-	BaseType "Flask"
-	Quality >= 1
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-
-Show
-	Class "Utility Flasks"
-	SetBackgroundColor 75 75 75
-	SetBorderColor 0 0 0
-	ItemLevel < 74
-
-#------------------------------------------------------------------------
-# 0801 # HIDE OUTDATED FLASKS
-#------------------------------------------------------------------------
-
-Hide
-	Class "Life Flask" "Mana Flask"
-	BaseType Flask
-	ItemLevel >= 35
-	BaseType Small Medium Large Greater Grand
-	SetFontSize 20
-
-Hide
-	Class "Life Flask" "Mana Flask"
-	BaseType Flask
-	ItemLevel >= 53
-	BaseType Giant Colossal Sacred
-	SetFontSize 20
-
-#----------------------------------------------------
-# 0802 # HIDE NON-QUALITY RANDOM FLASK DROPS IN MAPS
-#----------------------------------------------------
-
-Hide # Endgame: Hide non quality flasks in maps
-	BaseType Flask
-	ItemLevel >= 69
-	SetFontSize 20
-
-#----------------------------------------------------
-# 0803 # FLASKS - Hybrid Flasks (Normal)
-#----------------------------------------------------
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Small"
-	Rarity Normal
-	ItemLevel <= 15
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Medium"
-	Rarity Normal
-	ItemLevel <= 25
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Large"
-	Rarity Normal
-	ItemLevel <= 35
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Colossal"
-	Rarity Normal
-	ItemLevel <= 45
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Sacred"
-	Rarity Normal
-	ItemLevel <= 55
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Hallowed"
-	Rarity Normal
-	ItemLevel <= 67
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-#----------------------------------------------------
-# 0804 # FLASKS - Hybrid Flasks (Magic)
-#----------------------------------------------------
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Small"
-	Rarity Magic
-	ItemLevel <= 15
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Medium"
-	Rarity Magic
-	ItemLevel <= 25
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Large"
-	Rarity Magic
-	ItemLevel <= 35
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Colossal"
-	Rarity Magic
-	ItemLevel <= 45
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Sacred"
-	Rarity Magic
-	ItemLevel <= 55
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Hybrid Flask"
-	BaseType "Hallowed"
-	Rarity Magic
-	ItemLevel <= 66
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-#----------------------------------------------------
-# 0805 # FLASKS - HIGHLIGHT NEW NORMAL FLASKS (Kudos to Antnee)
-#----------------------------------------------------
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 5
-	BaseType "Small"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 8
-	ItemLevel >= 3
-	BaseType "Medium"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 12
-	ItemLevel >= 5
-	BaseType "Large"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 18
-	ItemLevel >= 12
-	BaseType "Greater"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 24
-	ItemLevel >= 18
-	BaseType "Grand"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 30
-	ItemLevel >= 24
-	BaseType "Giant"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 37
-	ItemLevel >= 30
-	BaseType "Colossal"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 42
-	ItemLevel >= 36
-	BaseType "Sacred"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 48
-	ItemLevel >= 42
-	BaseType "Hallowed"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 55
-	ItemLevel >= 48
-	BaseType "Sanctified"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 66
-	ItemLevel >= 60
-	BaseType "Divine"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Normal
-	ItemLevel <= 66
-	ItemLevel >= 65
-	BaseType "Eternal"
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-#----------------------------------------------------
-# 0806 # FLASKS - HIGHLIGHT NEW MAGIC FLASKS (Kudos to Antnee)
-#----------------------------------------------------
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 5
-	BaseType "Small"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 8
-	ItemLevel >= 3
-	BaseType "Medium"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 12
-	ItemLevel >= 5
-	BaseType "Large"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 18
-	ItemLevel >= 12
-	BaseType "Greater"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 24
-	ItemLevel >= 18
-	BaseType "Grand"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 30
-	ItemLevel >= 24
-	BaseType "Giant"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 37
-	ItemLevel >= 30
-	BaseType "Colossal"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 42
-	ItemLevel >= 36
-	BaseType "Sacred"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 48
-	ItemLevel >= 42
-	BaseType "Hallowed"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 55
-	ItemLevel >= 48
-	BaseType "Sanctified"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 67
-	ItemLevel >= 60
-	BaseType "Divine"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class Flask
-	Rarity Magic
-	ItemLevel <= 66
-	ItemLevel >= 65
-	BaseType "Eternal"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-#------------------------------------------------------------------------
-# 0807 # SHOW WHATEVER FLASKS REMAIN
-#------------------------------------------------------------------------
-
-Show
-	BaseType Flask
-	SetFontSize 29
-	Rarity <= Magic
-
-#------------------------------------------------------------------------
-# Section: 0900 # LEVELING
-#------------------------------------------------------------------------
-#Until itemlevel 12 you will see everything
-#Then NORMAL items under your level will SLOWLY start getting filtered out.
-#We will still see all 3L's until level 30 and all 4L's until level 69
-#All magic items will be visible without further filtering until level 67
-#
-#There's some additional highlight implemented for demanded rushing/leveling items, such as:
-#Low level boots (can roll movementspeed)
-#Low level sceptre+wands (if blue/3L)
-#Low level jewelery
-#Low level Quicksilver flasks (handled in a different section)
-
-#------------------------------------------------------------------------
-# 0901 # HIGHLIGHT LEVELING JEWELRY
-#------------------------------------------------------------------------
-
-Show
-	Rarity Normal
-	ItemLevel < 15
-	Class "Rings" "Amulets" "Belts"
-	SetBorderColor 100 100 100
-	SetTextColor 255 255 255 255
-	SetFontSize 36
-
-Show
-	Rarity Magic
 	ItemLevel < 20
-	Class "Rings" "Amulets" "Belts"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
+	SetFontSize 35
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
 
-Show
-	Rarity Normal
-	ItemLevel < 35
-	Class "Rings" "Amulets" "Belts"
-	SetTextColor 255 255 255 255
+Show #leveling, ok
+	Rarity Rare
+	ItemLevel < 65
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 225         # BACKGROUND:	 Rares - Basetype - OK
 
-Show
-	Rarity Magic
-	ItemLevel < 45
-	Class "Rings" "Amulets" "Belts"
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
+#===============================================================================================================
+# [[2200]] LEVELING - Useful items
+#===============================================================================================================
 
-Show # Leveling: Show magic rings, amulets and belts. Don't reduce font size
-	Class Rings Amulets Belts
-	Rarity Magic
-	ItemLevel <= 66		
+#------------------------------------
+#   [2201] Leveling RGB Exceptions 3L
+#------------------------------------
 
-#------------------------------------------------------------------------
-# 0902 # HIGHLIGHT LEVELING SPECIFIC ITEMS
-#------------------------------------------------------------------------
-Show
-	Class "Boots"
+Show #$rgb, small, lvl
 	LinkedSockets = 4
-	Rarity = Magic
-	ItemLevel < 68
-	SetFontSize 38
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100 255
+	SocketGroup RGB
+	Class "Gloves" "Boots" "Helmets" "Body Armour"
+	ItemLevel < 65
+	SetFontSize 40
+	SetBorderColor 100 100 200 255       # BORDERCOLOR:	 Leveling: 4-link
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
 
-Show
-	Class "Boots"
-	Rarity = Magic
-	ItemLevel < 25
+Show #$rgb, small, lvl
+	SocketGroup RGB
+	Width <= 2
+	Height <= 2
+	ItemLevel < 65
 	SetFontSize 38
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100 255
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
 
-Show
-	Class "Sceptres" "Wands"
-	Rarity = Magic
-	LinkedSockets = 3
+Show #$rgb, small, lvl
+	SocketGroup RGB
+	Width <= 1
+	Height <= 3
+	SetFontSize 38
+	SetBorderColor 150 150 150           # BORDERCOLOR:	 Rares - Size - Small (+Good basetype), Recipe: small/high qual
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$rgb, bulky, lvl
+	SocketGroup RGB
+	Width >= 2
+	Height >= 4
+	SetFontSize 34
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+Show #$rgb, lvl
+	SocketGroup RGB
+	SetFontSize 36
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+#------------------------------------
+#   [2202] Jewellery & Helpful leveling and racing gear
+#------------------------------------
+
+Show #topaz ring for act 2+3 racing %TB-LVL35-Trinkets
+	BaseType "Topaz Ring" "Two-Stone"
+	Rarity Normal
+	ItemLevel > 12
 	ItemLevel < 35
 	SetFontSize 38
-	SetBorderColor 100 100 100 255
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
-	Class "Sceptres" "Wands"
-	Rarity = Magic
-	ItemLevel < 25
+Show #topaz ring for act 2+3 racing %TB-LVL35-Trinkets
+	BaseType "Topaz Ring" "Two-Stone"
+	Rarity Magic
+	ItemLevel > 12
+	ItemLevel < 35
 	SetFontSize 38
-	SetBorderColor 100 100 100 255
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-#------------------------------------------------------------------------	
-# 0903 # HIGHLIGHT LEVELING LINKED GEAR
-#------------------------------------------------------------------------
-
-Show
-	LinkedSockets >= 4
-	ItemLevel <= 66
-	Rarity Normal
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	LinkedSockets >= 4
-	ItemLevel <= 66
-	Rarity Magic
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Gloves" "Boots" "Helmets" "Shields"
-	LinkedSockets >= 3
-	ItemLevel <= 25
-	Rarity Normal
-	SetTextColor 255 255 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-Show
-	Class "Gloves" "Boots" "Helmets" "Shields"
-	LinkedSockets >= 3
-	ItemLevel <= 25
-	Rarity Magic
-	SetTextColor 100 100 255 255
-	SetBorderColor 100 100 100
-	SetFontSize 36
-
-#------------------------------------------------------------------------
-# 0904 # LEVELING WHITE/MAGIC ITEM PROGRESSION
-#------------------------------------------------------------------------
-
-Show
-	ItemLevel < 12
-	SetBorderColor 0 0 0
-
-Show
-	Rarity Normal
-	ItemLevel < 13
-	DropLevel >= 2
-	SetBorderColor 0 0 0
-
-Show
-	Rarity Normal
-	ItemLevel < 14
-	DropLevel >= 4
-	SetBorderColor 0 0 0
-
-Show
-	Rarity Normal
-	ItemLevel < 16
-	DropLevel >= 6
-	SetBorderColor 0 0 0
-
-Show
+Show #$trinkets, lvl %TB-LVL18-Trinkets
+	BaseType "Amber Amulet" "Jade Amulet" "Lapis Amulet"
 	Rarity Normal
 	ItemLevel < 18
-	DropLevel >= 8
-	SetBorderColor 0 0 0
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
+Show #$trinkets, lvl %TB-LVL18-Trinkets
+	BaseType "Amber Amulet" "Jade Amulet" "Lapis Amulet"
+	Rarity Magic
+	ItemLevel < 18
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl %TB-LVL12-Trinkets
+	BaseType "Coral Ring" "Sapphire Ring" "Leather Belt"
 	Rarity Normal
+	ItemLevel < 12
+	SetFontSize 40
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl %TB-LVL12-Trinkets
+	BaseType "Coral Ring" "Sapphire Ring" "Leather Belt"
+	Rarity Magic
+	ItemLevel < 12
+	SetFontSize 40
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl %TB-Brutus-Handling-Gear
+	BaseType "Battered Helm" "Leatherscale Boots" "Light Brigandine" "Fishscale Gauntlets" "Light Brigandine" "Scale Vest"
+	Rarity Normal
+	ItemLevel <= 9
+	SetFontSize 36
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl %TB-Brutus-Handling-Gear
+	BaseType "Battered Helm" "Leatherscale Boots" "Light Brigandine" "Fishscale Gauntlets" "Light Brigandine" "Scale Vest"
+	Rarity Magic
+	ItemLevel <= 9
+	SetFontSize 36
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl
+	Class "Rings" "Amulets" "Belts"
+	Rarity Normal
+	ItemLevel < 15
+	SetFontSize 36
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$trinkets, lvl
+	Class "Rings" "Amulets" "Belts"
+	Rarity Magic
 	ItemLevel < 20
-	DropLevel >= 10
-	SetBorderColor 0 0 0
+	SetFontSize 36
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
+Show #$trinkets, lvl
+	Class "Rings" "Amulets" "Belts"
 	Rarity Normal
-	ItemLevel < 22
-	DropLevel >= 13
-	SetBorderColor 0 0 0
+	ItemLevel < 35
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
 
-Show
-	Rarity Normal
-	ItemLevel < 24
-	DropLevel >= 16
-	SetBorderColor 0 0 0
+Show #$trinkets, lvl
+	Class "Rings" "Amulets" "Belts"
+	Rarity Magic
+	ItemLevel < 45
+	SetFontSize 34
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
-	Rarity Normal
-	ItemLevel < 26
-	DropLevel >= 19
-	SetBorderColor 0 0 0
+Show #$trinkets, lvl, quivers
+	Class Rings Amulets Belts Quivers
+	Rarity Magic
+	ItemLevel <= 66
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
 
-Show
-	Rarity Normal
-	ItemLevel < 28
-	DropLevel >= 22
-	SetBorderColor 0 0 0
+#------------------------------------
+#   [2203] Caster weapons
+#------------------------------------
 
-Show
-	LinkedSockets >= 3
-	ItemLevel < 30
-	DropLevel >= 24
-	SetFontSize 32
+Show #$lvl, caster
+	LinkedSockets = 3
+	Class "Sceptres" "Wands" "Daggers"
 	Rarity <= Magic
-	SetBorderColor 75 75 75
+	ItemLevel < 35
+	SetFontSize 36
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
-	Rarity <= Magic
-	ItemLevel < 30
-	DropLevel >= 28
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 32
-	DropLevel >= 26
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 32
-	DropLevel >= 30
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 34
-	DropLevel >= 28
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 34
-	DropLevel >= 32
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 36
-	DropLevel >= 32
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 36
-	DropLevel >= 34
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 38
-	DropLevel >= 34
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 38
-	DropLevel >= 37
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 40
-	DropLevel >= 37
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 40
-	DropLevel >= 39
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 42
-	DropLevel >= 39
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 42
-	DropLevel >= 41
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 46
-	DropLevel >= 43
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 46
-	DropLevel >= 45
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 48
-	DropLevel >= 46
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 48
-	DropLevel >= 47
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 50
-	DropLevel >= 48
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 50
-	DropLevel >= 49
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 52
-	DropLevel >= 50
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 52
-	DropLevel >= 52
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 54
-	DropLevel >= 52
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 54
-	DropLevel >= 54
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 56
-	DropLevel >= 54
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 56
-	DropLevel >= 56
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 58
-	DropLevel >= 56
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 58
-	DropLevel >= 58
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 60
-	DropLevel >= 58
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 60
-	DropLevel >= 60
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 62
-	DropLevel >= 60
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 62
-	DropLevel >= 62
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 64
-	DropLevel >= 63
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 64
-	DropLevel >= 64
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 66
-	DropLevel >= 65
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-Show
-	Rarity <= Magic
-	ItemLevel < 66
-	DropLevel >= 66
-	SetFontSize 32
-	SetBorderColor 0 0 0
-
-Show
-	LinkedSockets >= 3
-	ItemLevel < 68
-	DropLevel >= 67
-	SetFontSize 32
-	Rarity <= Magic
-	SetBorderColor 75 75 75
-
-#------------------------------------------------------------------------
-# 0905 # LEVELING GENERAL RULES
-#------------------------------------------------------------------------
-
-Show
+Show #$lvl, caster
 	Class "Sceptres" "Wands" "Daggers"
 	Rarity = Magic
-	ItemLevel < 66
+	ItemLevel < 25
+	SetFontSize 36
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
 
-Show
+#------------------------------------
+#   [2204] Linked gear
+#------------------------------------
+
+Show #$lvl, links
+	LinkedSockets >= 4
+	Rarity Normal
+	ItemLevel <= 66
+	SetFontSize 40
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 200 255       # BORDERCOLOR:	 Leveling: 4-link
+
+Show #$lvl, links
+	LinkedSockets >= 4
+	Rarity Magic
+	ItemLevel <= 66
+	SetFontSize 40
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 200 255       # BORDERCOLOR:	 Leveling: 4-link
+
+Show #$lvl, links
+	LinkedSockets >= 3
+	Class "Gloves" "Boots" "Helmets" "Shields" "Body Armour"
+	Rarity Normal
+	ItemLevel <= 25
+	SetFontSize 36
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$lvl, links
+	LinkedSockets >= 3
+	Class "Gloves" "Boots" "Helmets" "Shields" "Body Armour"
+	Rarity Magic
+	ItemLevel <= 25
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$lvl, small
+	Class "Boots"
+	Rarity = Magic
+	ItemLevel < 25
+	SetFontSize 38
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$lvl, links
+	LinkedSockets >= 3
+	Class "Gloves" "Boots" "Helmets" "Shields" "Body Armour"
+	Rarity Normal
+	ItemLevel <= 60
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$lvl, links
+	LinkedSockets >= 3
+	Class "Gloves" "Boots" "Helmets" "Shields" "Body Armour"
+	Rarity Magic
+	ItemLevel <= 60
+	SetTextColor 100 100 255 255         # TEXTCOLOR: Magic Items: Strong Highlight
+	SetBorderColor 100 100 100 255       # BORDERCOLOR:	 Leveling: strong highlight
+
+Show #$lvl, other
+	LinkedSockets >= 3
+	Rarity Normal
+	ItemLevel < 12
+	SetFontSize 36
+	SetTextColor 255 255 255 225         # TEXTCOLOR:	 Early Leveling: Neutral 3Ls
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show #$lvl, other
+	LinkedSockets >= 3
+	Rarity Magic
+	ItemLevel < 12
+	SetFontSize 36
+	SetTextColor 100 100 255 225         # TEXTCOLOR:	 Early Leveling: Neutral 3Ls (magic)
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+#------------------------------------
+#   [2205] 20% quality items for those strange people who want them
+#------------------------------------
+
+Show #$recipe, quality, lvl, nonmf
+	Quality = 20
+	Class "Body Armour" "Helmets" "Gloves" "Boots" "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers" "Shields"
+	Rarity <= Magic
+	ItemLevel <= 60
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 75 75 75          # BACKGROUND:	 Recipes
+
+#===============================================================================================================
+# [[2300]] Levelling - normal and magic item progression
+#===============================================================================================================
+
+#------------------------------------
+#   [2301] Normal items - First 12 levels - exceptions
+#------------------------------------
+
+Show #$start, lvl, bulky
+	Width = 2
+	Height >= 3
+	Class "Body Armours" "Shields"
+	Rarity Normal
+	ItemLevel < 12
+	SetTextColor 200 200 200 180         # TEXTCOLOR:	 Early Leveling: Slowing bases
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show #$start, lvl, bulky
+	Width = 2
+	Height >= 4
+	Rarity Normal
+	ItemLevel < 12
+	SetTextColor 200 200 200 180         # TEXTCOLOR:	 Early Leveling: Slowing bases
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show #$start, lvl, small
+	Width <= 1
+	Height <= 4
+	Rarity Normal
+	ItemLevel <= 12
+	SetTextColor 200 200 200 255         # TEXTCOLOR:	 Early Leveling: Small bases
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show #$start, lvl, small
+	Width <= 2
+	Height <= 2
+	Rarity Normal
+	ItemLevel <= 12
+	SetTextColor 200 200 200 255         # TEXTCOLOR:	 Early Leveling: Small bases
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show #$start, lvl
+	Rarity Normal
+	ItemLevel < 12
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#------------------------------------
+#   [2302] Normal weapons - progression
+#------------------------------------
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 8
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 13
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 9
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 14
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 11
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 16
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 14
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 18
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 17
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 20
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 19
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 22
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 21
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 24
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 24
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 26
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 26
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 28
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 28
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
 	ItemLevel < 30
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 30
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 32
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 32
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 34
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 34
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 36
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 37
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 38
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 39
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 40
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 41
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 42
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 46
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 48
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 48
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 50
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 50
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 52
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 52
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 54
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 54
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 56
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 56
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 58
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 60
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 62
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 65
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 66
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show # %TC-LVL-Weapons
+	DropLevel >= 67
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Daggers"
+	Rarity <= Magic
+	ItemLevel < 67
+	SetFontSize 30
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+#------------------------------------
+#   [2303] Magic items - progression
+#------------------------------------
+
+Show #$start, lvl, bulky
+	Width = 2
+	Height >= 3
+	Class "Body Armours" "Shields"
 	Rarity Magic
-	SetBorderColor 0 0 0	
-	
+	ItemLevel < 12
+	SetTextColor 156 156 235 180         # TEXTCOLOR:	 Early Leveling: Bulky Magic Item
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show #$start, lvl, bulky
+	Width = 2
+	Height >= 4
+	Rarity Magic
+	ItemLevel < 12
+	SetTextColor 156 156 235 180         # TEXTCOLOR:	 Early Leveling: Bulky Magic Item
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
+Show #$start, lvl, small
+	Width <= 1
+	Height <= 4
+	Rarity Magic
+	ItemLevel <= 12
+	SetTextColor 136 136 255 240         # TEXTCOLOR:	 Early Leveling: Decent magic item
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show #$start, lvl, small
+	Width <= 2
+	Height <= 2
+	Rarity Magic
+	ItemLevel <= 12
+	SetTextColor 136 136 255 240         # TEXTCOLOR:	 Early Leveling: Decent magic item
+	SetBorderColor 50 50 50              # BORDERCOLOR:	 Leveling: light highlight
+	SetBackgroundColor 0 0 0 185         # BACKGROUND:	 Highlight - low maps, low priority items
+
+Show #$start, lvl
+	Rarity Magic
+	ItemLevel < 12
+	SetFontSize 32
+	SetTextColor 136 136 255 240         # TEXTCOLOR:	 Early Leveling: Decent magic item
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
+
 Show
-	ItemLevel < 45
 	Rarity Magic
-	SetBorderColor 0 0 0
-	SetFontSize 25
+	ItemLevel < 24
+	SetFontSize 32
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
 
-#------------------------------------------------------------------------
-# Section: 5000 # TEMP AND WIP ENTRIES
-#------------------------------------------------------------------------
-#Work-in-progress entries are added here
+Show
+	Rarity Magic
+	ItemLevel < 36
+	SetFontSize 26
+	SetBorderColor 0 0 0                 # BORDERCOLOR:	 Cosmetic: Neutral Highlight
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
 
-#------------------------------------------------------------------------
-# 5001 # WARBAND MODS - DEACTIVATED
-#------------------------------------------------------------------------
+#===============================================================================================================
+# [[2400]] HIDE LAYER 5 - Remaining Items
+#===============================================================================================================
 
-#Hide
-#Rarity Magic
-#Class "Helmets"
-#SetBorderColor 175 30 30
-#SetBackgroundColor 200 60 0 175
-#SetFontSize 29
+Hide # Minimize junk instead of hiding (if "Show") %TC-Junkable
+	Class "Two Hand" "Bows" "One Hand" "Wand" "Sceptre" "Staves" "Claws" "Body Armour" "Gloves" "Boots" "Helmets" "Quivers" "Flask" "Daggers" "Shields" "Belts" "Rings" "Amulets"
+	SetFontSize 26
+	SetBorderColor 0 0 0 150             # BORDERCOLOR:	 Cosmetic: Levelling-Trash
+	SetBackgroundColor 0 0 0 165         # BACKGROUND:	 Leveling, low alch bases
 
-#Hide
-#Rarity Magic
-#Class "Gloves"
-#SetBorderColor 30 0 175
-#SetBackgroundColor 50 25 150 175
-#SetFontSize 29
+#===============================================================================================================
+# [[2500]] CATCHALL - if you see pink items - send me a mail please - should never happen
+#===============================================================================================================
 
-#Hide
-#Rarity Magic
-#Class "Boots"
-#SetBorderColor 25 150 90
-#SetBackgroundColor 50 125 125 175
-#SetFontSize 29
-
-#---------------------------------------------------------------------------------------------------------------
-# Section: OMEGA # ADDITIONAL RULES - ADD YOUR OWN RULES THAT WON'T OVERRIDE THE OTHER RULES
-#---------------------------------------------------------------------------------------------------------------
-#This is the spot to add your own rules, that would not invalidate any rules above, but may highlight otherwise hidden things
-
-#------------------------------------------------------------------------
-# Section: XXXX # HIDE THE REST THEN FAILSAFE DISPLAY
-#------------------------------------------------------------------------
-#You can replace the "hide" with a "show" below to display all hidden items in a really small font.
-
-Hide # Minimize junk instead of hiding (if "Show")
-Rarity Magic
-SetFontSize 23
-SetBackgroundColor 0 0 0 150
-SetBorderColor 0 0 0 150
-
-Hide # Minimize junk instead of hiding (if "Show")
-Rarity Normal
-SetFontSize 20
-SetBackgroundColor 0 0 0 100
-SetBorderColor 0 0 0 100
-
-# This filter should classify every single item ingame. In case I somehow forgot an item (unlikely after monthes of testing) or something completely new gets added (such as a new rarity like "setitems" or a new itemslot, idk. "wings", this line will ensure, that you'll notice it). Though once again, highly unlikely.
-# Still I doubt it'll ever happen. However, if it will, please inform me!
 Show # SafetyLine!
-SetFontSize 45
-SetBorderColor 255 0 0 255
+	SetFontSize 45
+	SetTextColor 255 0 255 255           # TEXTCOLOR:	 SAFETY LINE
+	SetBorderColor 255 0 255 255         # BORDERCOLOR:	 SAFETY LINE
 
-#---------------------------------------------------------------------------------------------------------------
-# CREDITS
-#---------------------------------------------------------------------------------------------------------------
-# SCRIPT by NeverSink ( the-dude- on reddit )
+#===============================================================================================================
+# [[2600]] Special thanks to!
+#===============================================================================================================
 #
-# GGG - Thanks for the awesome game!
-# "GGG_Bex" - Special thanks for providing information to keep the filter running well on league starts!
+# COMMUNITY:
+# Special thanks to the supporters, stream-viewers and my guild :)
+# Everyone who provided feedback on my thread/github and on reddit.
 #
-# My awesome stream/reddit audience and for their energy!
+# GRINDING GEAR GAMES:
+# Bex - Awesome. Also compiled information for smooth updating during league starts!
+# Jonathan - Thank you for going into the detail on the filter algorithm. Also for the filter algorithm!
+# Chris - The man.
 #
-# "c4pture" - Special thank you for helping out with the testing of the filter, for his advise and for the fact that he's annoying ONLY half of the time :P.
+# FRIENDS:
+# Haggis & Tobnac - I'd need to a document to list all the things they've assisted with. Also members of the "Filterblade" project!
+# C4pture - Good friend, helped out a lot and is nice enough to only annoy me 75% of the time. He has a straaange cat.
+# MrPing - Helped out a ton with testing recently.
+# Victoria - <3
 #
-# "Helmannn" - for helping to test the filter during the Ascendancy Alpha!
-# "Malchron" - for helping out with his advice. And stuff.
-# "Antnee" - adapted some of his ideas. Also helped with feedback. He also has a nice lootfilter himself, check it out.
-# "Ghudda" - I took his script as a template. It made learning the syntax even easier.
-# "StarRune" - Found several flaws and improvement possibilities. Thanks!
+# SUGGESTIONS / HELP:
+# Antnee - adapted some of his ideas. Also helped with feedback. He also has a nice lootfilter himself, check it out.
+# Ghudda - I took his script as a template. It made learning the syntax even easier.
+# Malchron - consulted me on some complicated topics
+# ZiggyD - tested the filter during the 2.0 beta
+# Helmannn - tested the filter during the Ascendancy Alpha!
+# StarRune - Found several flaws and improvement possibilities. Thanks!
 # Also thanks to http://bschug.github.io/poedit/poedit.html - I used this site to test my setup
+#
+# Script by NeverSink


### PR DESCRIPTION
----------------------------------
NeverSink's itemfilter - version 4.63 - Bugfixing
----------------------------------
- Hotfixed a bug inroduced in 4.62, that didn't highlight rare 6-links
correctly (it highlighted them as 6S, instead of 6L)
- Moved emperor of purity a tier down
- Removed the custom purple style currency color for now. I'll change it
to something else later.

----------------------------------
NeverSink's itemfilter - version 4.61 - Economy Update
----------------------------------
- Updated the unique item tierlist to match the current economy
- Updated the divination card tierlist to match the current economy
- Added a very small LeagueStone tierlist - Breach, Perandus and Nemesis
stones have a slightly higher highlight. The tierlist also considers
rarity.
- Adjusted the colors for LeagueStones to be more polished
- Adjusted the colors of Legacy Relic Keys to be orange instead of
green, because the green receives a strange border and looks fairly
ugly.
- Fixed a bug, that was not correctly classifying a fraction of all
dropped RGB-items during the leveling phase (initially the goal was to
improve performance/structure). I apologize for screw up.
- Fixed a few very minor bugs
- Added an example to the override section 2, that explains how to
enable 20% quality rare item highlight for those crazy people people who
want it
- The leather belt chance base is now no longer hidden on all versions,
except for uber-strict (that hides all chance bases). It still doesn't
make a sound to prevent sound polution.
- All non-drop-only, non-quality gems are now hidden starting with the
strict version.
- Basetypes with multiple uniques, where a certain version is super
expensive, but the common version is not (Onyx amulet, the tukohama
shield, goathide boots), now have their own tierlist. They look exactly
like all other tier 2 uniques, but don't make the "exalted orb" orb tier
1 sound anymore to prevent disapointments. They now make the "random
unique" sound. Tell me what you think about it.
- Several other minor adjustments
- Started work on additional styles, but got bored, *whispers*: next
time.
- Added a comment to the Ancient Relic Key entry: ""Ancient Reliquary
Key" - the following section handles it (it's classified as a ""Misc Map
Items" by GGG). No it's not hidden, stop asking me, crazy people.". -
Seriously, stop it. The reason, why you might not have found any is
because it's rare.
- [STRUCTURE] Split the unique tier list into Weapons/Flasks/Armors/Misc
items for each tier. This is mostly done in order to update easier and
might get reversed in a future update