### PR TITLE
Added what seems to be correct stats

### DIFF
--- a/src/Models/Enums/PlayerStats.cs
+++ b/src/Models/Enums/PlayerStats.cs
@@ -2,9 +2,37 @@
 {
     public enum PlayerStats
     {
-        ColdResistance = 308,
+        IncreasedSpellDamage = 26,
         FireResistance = 309,
+        ColdResistance = 308,
         LightningResistance = 310,
-        ChaosResistance = 311
+        ChaosResistance = 311,
+        TotalFireResistance = 2073,
+        TotalColdResistance = 2074,
+        TotalLightningResistance = 2075,
+        TotalChaosResistance = 2076,
+        MovementSpeed = 244,
+        MovementSpeed2 = 179,
+        Armour = 242,
+        Armour2 = 1082,
+        ChancetoBlockAttacks = 24,
+        ChancetoBlockAttacks2 = 1087,
+        ReducedFlaskChargesUsed = 747,
+        ToArmour = 117,
+        IncreasedPhysicalDamage = 27,
+        PercentIncreasedChaosDamage = 64,
+        PercentIncreasedAttacksSpeed = 71,
+        AdditionalRemoteMinesPlacedAtATime = 967,
+        IncreasedManaReserved = 860,
+        GainPercentofPhysicalDamageAsExtraChaosDamage = 452,
+        Evasion = 283,
+        FlatEvasionRatingFromItemsOrTree = 120,
+        IncreasedRarity = 671,
+        ManaGainedOnKill = 2433,
+        EstimatedChanceToaAvoidAttacks = 684,
+        EstimatedPhysicalDamageReduction = 726,
+        EstimatedPhysicalDamageReduction2 = 1088,
+        PercentIncreasedAttackSpeed2 = 293,
+        PercentIncreasedCastSpeed = 295
     }
 }


### PR DESCRIPTION
Do note, some have more than 1 ID that gets affected, like movement
speed and im guessing they are for different calculations from different
type off + to stat mods, those that i found with more than 1 have
"stat2" etc. there are a lot of interesting things i notice changing
when i equip a white wand that may or may not indicate main/offhand crit
chance and stuff like that. very interesting.