### PR TITLE
Don't load abstract plugin classes

### DIFF
--- a/src/Hud/PluginExtension/PluginExtensionPlugin.cs
+++ b/src/Hud/PluginExtension/PluginExtensionPlugin.cs
@@ -193,7 +193,7 @@ namespace PoeHUD.Hud.PluginExtension
 
             foreach (var type in asmTypes)
             {
-                if (type.IsSubclassOf(typeof(BasePlugin)))
+                if (type.IsSubclassOf(typeof(BasePlugin)) && !type.IsAbstract)
                 {
                     var extPlugin = new ExternalPlugin(type, this, dir);
                     Plugins.Add(extPlugin.BPlugin);


### PR DESCRIPTION
An exception was being thrown when attempting to load a plugin with an abstract class of type BasePlugin.