### PR TITLE
Fixed a few silent exceptions

### DIFF
--- a/src/Hud/PluginWithMapIcons.cs
+++ b/src/Hud/PluginWithMapIcons.cs
@@ -44,7 +44,9 @@ namespace PoeHUD.Hud
             }
             for (int i = 0; i < index; i++)
             {
-                CurrentIcons.Remove(toRemove[index]);
+                EntityWrapper entityToRemove = toRemove[index];
+                if (entityToRemove != null)
+                    CurrentIcons.Remove(entityToRemove);
             }
         }
     }

--- a/src/Hud/Sounds.cs
+++ b/src/Hud/Sounds.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Media;
 
 namespace PoeHUD.Hud
@@ -18,7 +19,8 @@ namespace PoeHUD.Hud
             {
                 try
                 {
-                    var soundPlayer = new SoundPlayer($"sounds/{name}");
+                    String path = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase), $"sounds/{name}");
+                    var soundPlayer = new SoundPlayer(path); 
                     soundPlayer.Load();
                     soundLib[name] = soundPlayer;
                 }


### PR DESCRIPTION
PluginWithMapIcons.cs - toRemove[index] would sometimes return null and cause an exception. Added a null check

Sounds.cs - Invalid URI format. Set to absolute path so that it works no matter what the current working directory is