### PR TITLE
Fixes to failed ReadProcessMemory calls

### DIFF
--- a/src/Framework/Memory.cs
+++ b/src/Framework/Memory.cs
@@ -79,6 +79,8 @@ namespace PoeHUD.Framework
             int result = num;
             for (var index = 0; index < offsets.Length; index++)
             {
+                if (result == 0)
+                    break;
                 var offset = offsets[index];
                 result = ReadInt(result + offset);
             }
@@ -92,13 +94,15 @@ namespace PoeHUD.Framework
             long result = num;
             for (var index = 0; index < offsets.Length; index++)
             {
+                if (result == 0)
+                    break;
                 var offset = offsets[index];
                 result = ReadLong(result + offset);
             }
             return (int)result;
         }
 
-      
+
 
 
         public float ReadFloat(long addr)
@@ -118,6 +122,8 @@ namespace PoeHUD.Framework
             long result = num;
             for (var index = 0; index < offsets.Length; index++)
             {
+                if (result == 0)
+                    break;
                 var offset = offsets[index];
                 result = ReadLong(result + offset);
             }
@@ -181,7 +187,7 @@ namespace PoeHUD.Framework
             if (mem[0] == 0 && mem[1] == 0)
             {
                 var checkByte = ReadByte(addr);
-                if(checkByte != 0)  
+                if (checkByte != 0)
                 {
                     //Reading an array of bytes gives us a 0 first byte and manual reading the first byte gives us not 0,
                     //mean that this was a reading out of memory region, we will try to read with step of 10 bytes, 
@@ -190,7 +196,7 @@ namespace PoeHUD.Framework
                     const int step = 8;//should be 'even' number (2,4,6,8, etc) (or remove if (bytes[0] == 0) check) 
                                        //because each second byte of string is 0
                     string result = "";
-                
+
                     for (int offset = 0; offset < length; offset += step)
                     {
                         var bytes = ReadMem(addr + offset, step);
@@ -200,8 +206,8 @@ namespace PoeHUD.Framework
 
                         var partialString = Encoding.Unicode.GetString(bytes);
                         result += partialString;
-                       
-                        if(replaceNull && partialString.Contains('\0'))
+
+                        if (replaceNull && partialString.Contains('\0'))
                         {
                             return RTrimNull(result);
                         }
@@ -230,7 +236,7 @@ namespace PoeHUD.Framework
             {
                 var offset = offsets[index];
 
-                if(index < offsets.Length - 1)
+                if (index < offsets.Length - 1)
                     result = ReadLong(result + offset);
                 else
                     result = ReadByte(result + offset);
@@ -266,7 +272,7 @@ namespace PoeHUD.Framework
             var range = endAddress - startAddress;
             if (range < 0 || range / structSize > maxCountLimit)
             {
-                if(PoeHUD.Hud.MainMenuWindow.Settings.DeveloperMode.Value)
+                if (PoeHUD.Hud.MainMenuWindow.Settings.DeveloperMode.Value)
                     DebugPlug.DebugPlugin.LogMsg($"Fixed possible memory leak while reading array of struct '{typeof(T).Name}'", 1, SharpDX.Color.Yellow);
                 return result;
             }
@@ -340,7 +346,7 @@ namespace PoeHUD.Framework
 
         //Temporary for reading QustStates
         //Hope some day this will be replaced with GrayMagic dll to read generic structs https://github.com/Konctantin/GreyMagic
-        public List<Tuple<long, int>> ReadDoublePointerIntList(long address) 
+        public List<Tuple<long, int>> ReadDoublePointerIntList(long address)
         {
             var list = new List<Tuple<long, int>>();
             var head = ReadLong(address + 0x8);
@@ -453,7 +459,7 @@ namespace PoeHUD.Framework
 
                 bool found = false;
 
-                for (int offset = 0; offset < exeImage.Length - patternLength; offset ++)
+                for (int offset = 0; offset < exeImage.Length - patternLength; offset++)
                 {
                     if (CompareData(pattern, exeImage, offset))
                     {
@@ -464,7 +470,7 @@ namespace PoeHUD.Framework
                     }
                 }
 
-                if(!found)
+                if (!found)
                 {
                     DebugStr += "Pattern " + iPattern + " is not found!" + Environment.NewLine;
                 }

--- a/src/Poe/RemoteMemoryObject.cs
+++ b/src/Poe/RemoteMemoryObject.cs
@@ -1,5 +1,6 @@
 using PoeHUD.Framework;
 using PoeHUD.Poe.RemoteMemoryObjects;
+using System;
 
 namespace PoeHUD.Poe
 {
@@ -50,6 +51,29 @@ namespace PoeHUD.Poe
         {
             var remoteMemoryObject = obj as RemoteMemoryObject;
             return remoteMemoryObject != null && remoteMemoryObject.Address == Address;
+        }
+
+        public static bool operator ==(RemoteMemoryObject lhs, RemoteMemoryObject rhs)
+        {
+            // Check for null on left side.
+            if (Object.ReferenceEquals(lhs, null) || lhs.Address == 0)
+            {
+                if (Object.ReferenceEquals(rhs, null) || lhs.Address == 0)
+                {
+                    // null == null = true.
+                    return true;
+                }
+
+                // Only the left side is null.
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(RemoteMemoryObject lhs, RemoteMemoryObject rhs)
+        {
+            return !(lhs == rhs);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Memory.cs - Added breaks (and thus return 0) if the result of the last read was 0. Reading address 0 + offset doesn't really work. This mostly seemed to be occuring on Entity.IsValid (specifically the internalEntity.IsValid call). The address sent in had a valid value, but reading the long returned 0 and it attempted to read [0+32}+0.

ReadMemoryObject.cs - Objects with the address of 0 will be equal to null. Some entities were being used/calling ReadProcessMemory with an address of 0. There may be a better way to do this, but there are many cases where calls such as Game.IngameState.IngameUi.ReadObjectAt<ItemsOnGroundLabelElement>(0xD58); are made and the return checked for null. As far as I can tell, the ObjectAt methods will never return null.