### PR TITLE
Fixing preloads, setting debug configuration to be not optimized, fix…

### DIFF
--- a/Release/config/preload_alerts.txt
+++ b/Release/config/preload_alerts.txt
@@ -423,9 +423,8 @@ Metadata/Chests/Abyss/AbyssFinalChest3; Abyss #3; ff00AA00
 Metadata/Chests/Abyss/AbyssFinalChest4; Abyss #4; ff00AA00
 
 # BETRAYAL
-Metadata/NPC/League/BetrayalNinjaCopRaid; Syndicate Research; ff00FF00
+Metadata/NPC/League/Betrayal/BetrayalNinjaCopRaid; Syndicate Research; ff00FF00
 Metadata/Monsters/LeagueBetrayal/FortWall/FortWall; Syndicate Fortification; ff00FF00
-Metadata/Monsters/LeagueBetrayal/BetrayalSecretPoliceChampion; Syndicate Interception; ff00FF00
 Metadata/Monsters/LeagueBetrayal/BetrayalOriathBlackguardMeleeChampionCartGuard; Syndicate Transportation; ff00FF00
 
 Metadata/Monsters/LeagueBetrayal/BetrayalCatarina; Catarina, Master of Undeath; ff36b4b4

--- a/src/Hud/ExternalOverlay.cs
+++ b/src/Hud/ExternalOverlay.cs
@@ -180,10 +180,10 @@ namespace PoeHUD.Hud
             plugins.Add(new AdvancedTooltipPlugin(gameController, graphics, settings.AdvancedTooltipSettings, settings));
             plugins.Add(new MenuPlugin(gameController, graphics, settings));
 
-            //await Task.Run(() =>
-            //{
+            await Task.Run(() =>
+            {
                 plugins.Add(new PluginExtensionPlugin(gameController, graphics)); //Should be after MenuPlugin
-            //});
+            });
 
             MainMenuWindow.Instance.SelectedPlugin = PluginExtensionPlugin.Plugins.Find(x => x.PluginName == MainMenuWindow.Settings.LastOpenedPlugin);
 

--- a/src/Hud/PluginExtension/PluginExtensionPlugin.cs
+++ b/src/Hud/PluginExtension/PluginExtensionPlugin.cs
@@ -208,13 +208,16 @@ namespace PoeHUD.Hud.PluginExtension
             }
 
             AppDomain.CurrentDomain.AppendPrivatePath(dir);
-            var myAsm = Assembly.Load(File.ReadAllBytes(path));
-            if (myAsm == null) return;
 
-            Type[] asmTypes = null;
+            Type[] asmTypes;
             try
             {
+                var myAsm = Assembly.LoadFrom(path);
                 asmTypes = myAsm.GetTypes();
+            }
+            catch (BadImageFormatException)
+            {
+                return;
             }
             catch (ReflectionTypeLoadException typeLoadException)
             {

--- a/src/Poe/RemoteMemoryObjects/ServerData.cs
+++ b/src/Poe/RemoteMemoryObjects/ServerData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using PoeHUD.Poe.Elements;
 using PoeHUD.Controllers;
 using PoeHUD.Poe.Components;
@@ -13,9 +14,9 @@ namespace PoeHUD.Poe.RemoteMemoryObjects
 		[Obsolete("Obsolete. Use GameController.Game.IngameState.IngameUi.StashElement instead")]
 	    public StashElement StashPanel => GameController.Instance.Game.IngameState.IngameUi.StashElement;// Address != 0 ? GetObject<StashElement>(M.ReadLong(Address + 0x4C8, 0xA0, 0x78)) : null; // needs fixed, but if it's obsolete, just remove it
 
-		public PartyStatus PartyStatusType => (PartyStatus)M.ReadByte(Address + 0x6188);
+		public PartyStatus PartyStatusType => (PartyStatus)M.ReadByte(Address + 0x6288);
 
-		public CharacterClass PlayerClass => (CharacterClass)(M.ReadByte(Address + 0x5F90) & 0xF);
+		public CharacterClass PlayerClass => (CharacterClass)(M.ReadByte(Address + 0x6090) & 0xF);
 
 		public List<ushort> PassiveSkillIds
 		{
@@ -140,8 +141,8 @@ namespace PoeHUD.Poe.RemoteMemoryObjects
 		{
 			get
 			{
-				var firstAddr = M.ReadLong(Address + 0x64B8); // double check these
-				var lastAddr = M.ReadLong(Address + 0x64C0);
+				var firstAddr = M.ReadLong(Address + 0x65B8); // double check these
+				var lastAddr = M.ReadLong(Address + 0x65C0);
 				return M.ReadStructsArray<InventoryHolder>(firstAddr, lastAddr, InventoryHolder.StructSize, 100);
 			}
 		}

--- a/src/PoeHUD.csproj
+++ b/src/PoeHUD.csproj
@@ -100,7 +100,7 @@
     <LangVersion>default</LangVersion>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">


### PR DESCRIPTION
1. Removed Syndicate Interception preload because the asset is always being loaded no matter what zone you're in.
2. Fixed Syndicate Research preload
3. Uncommented Task.Run around new PluginExtensionPlugin. Stridemann commented this out because he said it was giving him issues but I've been using it for over a year without issue. This class definitely hangs for a second or two when being created, so it's good to run it on a separate thread.
4. The Assembly.Load being used for plugins wasn't inside the try/catch so it could crash PoEHud instead off handling the exception. Generally, Assembly.LoadFrom is more robus than Assembly.Load anyways. I also added the catch for BadImageFormatException in the case that PoEHud attempts to load a 32bit plugin or non-C# dll.
5. Changed the debug configuration to not be optimized, this is necessary to hit any breakpoint while debugging. Not sure why it's set to true anyways. If you want to optimize, that's what the Release configuration is for.